### PR TITLE
Port commit to fix build with latest LLVM

### DIFF
--- a/llvm_util/llvm2alive.cpp
+++ b/llvm_util/llvm2alive.cpp
@@ -1493,14 +1493,14 @@ public:
     MemoryAccess attrs;
     attrs.setNoAccess();
 
-    array<pair<llvm::MemoryEffects::Location, MemoryAccess::AccessType>, 5> tys
+    array<pair<llvm::IRMemLocation, MemoryAccess::AccessType>, 5> tys
     {
-      make_pair(llvm::MemoryEffects::ArgMem,          MemoryAccess::Args),
-      make_pair(llvm::MemoryEffects::InaccessibleMem,
+      make_pair(llvm::IRMemLocation::ArgMem,          MemoryAccess::Args),
+      make_pair(llvm::IRMemLocation::InaccessibleMem,
                 MemoryAccess::Inaccessible),
-      make_pair(llvm::MemoryEffects::Other,           MemoryAccess::Other),
-      make_pair(llvm::MemoryEffects::Other,           MemoryAccess::Globals),
-      make_pair(llvm::MemoryEffects::Other,           MemoryAccess::Errno),
+      make_pair(llvm::IRMemLocation::Other,           MemoryAccess::Other),
+      make_pair(llvm::IRMemLocation::Other,           MemoryAccess::Globals),
+      make_pair(llvm::IRMemLocation::Other,           MemoryAccess::Errno),
     };
 
     for (auto &[ef, ty] : tys) {


### PR DESCRIPTION
This PR ports [b280fa03f3567a3832fac304921846ac77219f5d](https://github.com/AliveToolkit/alive2/commit/b280fa03f3567a3832fac304921846ac77219f5d)  commit from the main repo to fix the build with the latest LLVM