### PR TITLE
Handled globals not in Machine Function

### DIFF
--- a/tests/arm-tv/globals/global-test-101.aarch64.ll
+++ b/tests/arm-tv/globals/global-test-101.aarch64.ll
@@ -1,0 +1,9 @@
+target triple = "wasm32-unknown-emscripten"
+
+@g = external global [0 x i32], align 4
+
+define i32 @load_test5(i32 %0) {
+  %2 = getelementptr inbounds i32, ptr getelementptr inbounds ([0 x i32], ptr @g, i32 0, i32 10), i32 %0
+  %3 = load i32, ptr %2, align 4
+  ret i32 %3
+}

--- a/tests/arm-tv/globals/global-test-102.aarch64.ll
+++ b/tests/arm-tv/globals/global-test-102.aarch64.ll
@@ -1,0 +1,15 @@
+
+@g = external global i32
+
+define void @f1(i64 %0) {
+  %2 = and i64 %0, 4294967296
+  %3 = icmp eq i64 %2, 0
+  br i1 %3, label %5, label %4
+
+4:                                                ; preds = %1
+  store i32 1, ptr @g, align 4
+  br label %5
+
+5:                                                ; preds = %4, %1
+  ret void
+}

--- a/tests/arm-tv/globals/global-test-103.aarch64.ll
+++ b/tests/arm-tv/globals/global-test-103.aarch64.ll
@@ -1,0 +1,9 @@
+
+@glob = external local_unnamed_addr global i16, align 2
+
+define void @test_igtss_sext_z_store(i16 signext %0) {
+  %2 = icmp sgt i16 %0, 0
+  %3 = sext i1 %2 to i16
+  store i16 %3, ptr @glob, align 2
+  ret void
+}

--- a/tests/arm-tv/globals/global-test-104.aarch64.ll
+++ b/tests/arm-tv/globals/global-test-104.aarch64.ll
@@ -1,0 +1,15 @@
+
+@g = external global i32
+
+define void @f13(i32 %0) {
+  %2 = and i32 %0, 140
+  %3 = icmp ugt i32 %2, 126
+  br i1 %3, label %5, label %4
+
+4:                                                ; preds = %1
+  store i32 1, ptr @g, align 4
+  br label %5
+
+5:                                                ; preds = %4, %1
+  ret void
+}


### PR DESCRIPTION
Added code to create globals from LLVM source module if not created already due to absence in Machine Function (Do not remove Machine Function global creation. It has sizes along with globals whereas LLVM may not) Added few tests for globals not found in Machine Function