### PR TITLE
Supporting popcnt and extending shift instructions to vectors

### DIFF
--- a/tests/arm-tv/vectors/popcnt/test_16_8.aarch64.ll
+++ b/tests/arm-tv/vectors/popcnt/test_16_8.aarch64.ll
@@ -1,0 +1,8 @@
+define void @f2(ptr %a, ptr %b) {
+  %v1 = load <16 x i8>, ptr %a
+  %v2 = call <16 x i8> @llvm.ctpop.v16i8(<16 x i8> %v1)
+  store <16 x i8> %v2, ptr %b
+  ret void
+}
+
+declare <16 x i8> @llvm.ctpop.v16i8(<16 x i8>)

--- a/tests/arm-tv/vectors/popcnt/test_8_8.aarch64.ll
+++ b/tests/arm-tv/vectors/popcnt/test_8_8.aarch64.ll
@@ -1,0 +1,8 @@
+define void @f1(ptr %a, ptr %b) {
+  %v1 = load <8 x i8>, ptr %a
+  %v2 = call <8 x i8> @llvm.ctpop.v8i8(<8 x i8> %v1)
+  store <8 x i8> %v2, ptr %b
+  ret void
+}
+
+declare <8 x i8> @llvm.ctpop.v8i8(<8 x i8>)


### PR DESCRIPTION
Created a function to create an LLVM ConstantVector out of a vector of Constants
Created a function to create a mask value based on type of value and bitwidth
Used this function is LLVM shift creators
Added support and test cases for CNTv8i8 and CNTv16i8