### PR TITLE
Added support for strb, ldrb, strh and ldrh

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -304,39 +304,40 @@ class arm2llvm {
   };
 
   const set<int> instrs_32 = {
-      AArch64::ADDWrx,     AArch64::ADDSWrs,   AArch64::ADDSWri,
-      AArch64::ADDWrs,     AArch64::ADDWri,    AArch64::ADDSWrx,
-      AArch64::ADCWr,      AArch64::ADCSWr,    AArch64::ASRVWr,
-      AArch64::SUBWri,     AArch64::SUBWrs,    AArch64::SUBWrx,
-      AArch64::SUBSWrs,    AArch64::SUBSWri,   AArch64::SUBSWrx,
-      AArch64::SBFMWri,    AArch64::CSELWr,    AArch64::ANDWri,
-      AArch64::ANDWrr,     AArch64::ANDWrs,    AArch64::ANDSWri,
-      AArch64::ANDSWrr,    AArch64::ANDSWrs,   AArch64::MADDWrrr,
-      AArch64::MSUBWrrr,   AArch64::EORWri,    AArch64::CSINVWr,
-      AArch64::CSINCWr,    AArch64::MOVZWi,    AArch64::MOVNWi,
-      AArch64::MOVKWi,     AArch64::LSLVWr,    AArch64::LSRVWr,
-      AArch64::ORNWrs,     AArch64::UBFMWri,   AArch64::BFMWri,
-      AArch64::ORRWrs,     AArch64::ORRWri,    AArch64::SDIVWr,
-      AArch64::UDIVWr,     AArch64::EXTRWrri,  AArch64::EORWrs,
-      AArch64::RORVWr,     AArch64::RBITWr,    AArch64::CLZWr,
-      AArch64::REVWr,      AArch64::CSNEGWr,   AArch64::BICWrs,
-      AArch64::BICSWrs,    AArch64::EONWrs,    AArch64::REV16Wr,
-      AArch64::Bcc,        AArch64::CCMPWr,    AArch64::CCMPWi,
-      AArch64::LDRWui,     AArch64::LDRBBroW,  AArch64::LDRBBroX,
-      AArch64::LDRWroW,    AArch64::LDRWroX,   AArch64::LDRSui,
-      AArch64::LDRBBui,    AArch64::LDRBui,    AArch64::LDRSBWui,
-      AArch64::LDRSWui,    AArch64::LDRSHWui,  AArch64::LDRSBWui,
-      AArch64::LDRHHui,    AArch64::LDRHui,    AArch64::STRWui,
-      AArch64::STRBBroW,   AArch64::STRBBroX,  AArch64::STRWroW,
-      AArch64::STRWroX,    AArch64::CCMNWi,    AArch64::CCMNWr,
-      AArch64::STRBBui,    AArch64::STRBui,    AArch64::STPWi,
-      AArch64::STRHHui,    AArch64::STRHui,    AArch64::STURWi,
-      AArch64::STRSui,     AArch64::LDPWi,     AArch64::STRWpre,
-      AArch64::FADDSrr,    AArch64::FSUBSrr,   AArch64::FCMPSrr,
-      AArch64::FCMPSri,    AArch64::FMOVSWr,   AArch64::INSvi32gpr,
-      AArch64::INSvi16gpr, AArch64::INSvi8gpr, AArch64::FCVTSHr,
-      AArch64::FCVTZSUWSr, AArch64::FCSELSrrr, AArch64::FMULSrr,
-      AArch64::FABSSr,
+      AArch64::ADDWrx,     AArch64::ADDSWrs,    AArch64::ADDSWri,
+      AArch64::ADDWrs,     AArch64::ADDWri,     AArch64::ADDSWrx,
+      AArch64::ADCWr,      AArch64::ADCSWr,     AArch64::ASRVWr,
+      AArch64::SUBWri,     AArch64::SUBWrs,     AArch64::SUBWrx,
+      AArch64::SUBSWrs,    AArch64::SUBSWri,    AArch64::SUBSWrx,
+      AArch64::SBFMWri,    AArch64::CSELWr,     AArch64::ANDWri,
+      AArch64::ANDWrr,     AArch64::ANDWrs,     AArch64::ANDSWri,
+      AArch64::ANDSWrr,    AArch64::ANDSWrs,    AArch64::MADDWrrr,
+      AArch64::MSUBWrrr,   AArch64::EORWri,     AArch64::CSINVWr,
+      AArch64::CSINCWr,    AArch64::MOVZWi,     AArch64::MOVNWi,
+      AArch64::MOVKWi,     AArch64::LSLVWr,     AArch64::LSRVWr,
+      AArch64::ORNWrs,     AArch64::UBFMWri,    AArch64::BFMWri,
+      AArch64::ORRWrs,     AArch64::ORRWri,     AArch64::SDIVWr,
+      AArch64::UDIVWr,     AArch64::EXTRWrri,   AArch64::EORWrs,
+      AArch64::RORVWr,     AArch64::RBITWr,     AArch64::CLZWr,
+      AArch64::REVWr,      AArch64::CSNEGWr,    AArch64::BICWrs,
+      AArch64::BICSWrs,    AArch64::EONWrs,     AArch64::REV16Wr,
+      AArch64::Bcc,        AArch64::CCMPWr,     AArch64::CCMPWi,
+      AArch64::LDRWui,     AArch64::LDRBBroW,   AArch64::LDRBBroX,
+      AArch64::LDRHHroW,   AArch64::LDRHHroX,   AArch64::LDRWroW,
+      AArch64::LDRWroX,    AArch64::LDRSui,     AArch64::LDRBBui,
+      AArch64::LDRBui,     AArch64::LDRSBWui,   AArch64::LDRSWui,
+      AArch64::LDRSHWui,   AArch64::LDRSBWui,   AArch64::LDRHHui,
+      AArch64::LDRHui,     AArch64::STRWui,     AArch64::STRBBroW,
+      AArch64::STRBBroX,   AArch64::STRHHroW,   AArch64::STRHHroX,
+      AArch64::STRWroW,    AArch64::STRWroX,    AArch64::CCMNWi,
+      AArch64::CCMNWr,     AArch64::STRBBui,    AArch64::STRBui,
+      AArch64::STPWi,      AArch64::STRHHui,    AArch64::STRHui,
+      AArch64::STURWi,     AArch64::STRSui,     AArch64::LDPWi,
+      AArch64::STRWpre,    AArch64::FADDSrr,    AArch64::FSUBSrr,
+      AArch64::FCMPSrr,    AArch64::FCMPSri,    AArch64::FMOVSWr,
+      AArch64::INSvi32gpr, AArch64::INSvi16gpr, AArch64::INSvi8gpr,
+      AArch64::FCVTSHr,    AArch64::FCVTZSUWSr, AArch64::FCSELSrrr,
+      AArch64::FMULSrr,    AArch64::FABSSr,
   };
 
   const set<int> instrs_64 = {
@@ -1707,7 +1708,7 @@ public:
     return CurInst->getOperand(idx).getImm();
   }
 
-  enum ExtendType { UXTB, UXTH, UXTW, UXTX, SXTB, SXTH, SXTW, SXTX };
+  enum ExtendType { SXTB, SXTH, SXTW, SXTX, UXTB, UXTH, UXTW, UXTX };
 
   // Follows the "Library pseudocode for aarch64/instrs/extendreg/ExtendReg"
   // from ARM manual
@@ -1721,7 +1722,7 @@ public:
     //    auto size = getInstSize(opcode);
     auto size = 64;
     auto ty = getIntTy(size);
-    auto isSigned = (extType & 0x4) != 0;
+    auto isSigned = (extType & 0x4) != 0x4;
 
     // extendSize is necessary so that we can start with the word size
     // ARM wants us to (byte, half, full) and then sign extend to a new
@@ -1768,35 +1769,47 @@ public:
 
     int extTyp, shiftAmt;
     switch (CurInst->getOpcode()) {
-    case AArch64::LDRBBroW:
+    case AArch64::LDRBBroW: {
+      extTyp = extendTypeVal ? SXTW : UXTW;
+      shiftAmt = 0;
+      break;
+    }
+    case AArch64::LDRHHroW: {
+      extTyp = extendTypeVal ? SXTW : UXTW;
+      shiftAmt = shiftAmtVal ? 1 : 0;
+      break;
+    }
     case AArch64::LDRWroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
-      if (CurInst->getOpcode() == AArch64::LDRBBroW) {
-        assert(shiftAmtVal == 0 &&
-               "AArch64::LDRBBroW shift amount (5th operand) "
-               "is always 0");
-      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::LDRXroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
-    case AArch64::LDRBBroX:
-    case AArch64::LDRWroX:
-      // The manual assigns a value LSL to extTyp which for a value of 64
-      // bits, is the same as UXTX
+    case AArch64::LDRBBroX: {
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
-      if (CurInst->getOpcode() == AArch64::LDRBBroX) {
-        assert(shiftAmtVal == 0 &&
-               "AArch64::LDRBBroX shift amount (5th operand) "
-               "is always 0");
-      }
+      shiftAmt = 0;
+      break;
+    }
+    case AArch64::LDRHHroX: {
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
+      extTyp = extendTypeVal ? SXTX : UXTX;
+      shiftAmt = shiftAmtVal ? 1 : 0;
+      break;
+    }
+    case AArch64::LDRWroX:
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
+      extTyp = extendTypeVal ? SXTX : UXTX;
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::LDRXroX:
-      // The manual assigns a value LSL to extTyp which for a value of 64
-      // bits, is the same as UXTX
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
@@ -1874,13 +1887,15 @@ public:
     int extTyp, shiftAmt;
     switch (CurInst->getOpcode()) {
     case AArch64::STRBBroW:
+      extTyp = extendTypeVal ? SXTW : UXTW;
+      shiftAmt = 0;
+      break;
+    case AArch64::STRHHroW:
+      extTyp = extendTypeVal ? SXTW : UXTW;
+      shiftAmt = shiftAmtVal ? 1 : 0;
+      break;
     case AArch64::STRWroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
-      if (CurInst->getOpcode() == AArch64::STRBBroW) {
-        assert(shiftAmtVal == 0 &&
-               "AArch64::STRBBroW shift amount (5th operand) "
-               "is always 0");
-      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::STRXroW:
@@ -1888,20 +1903,26 @@ public:
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
     case AArch64::STRBBroX:
-    case AArch64::STRWroX:
-      // The manual assigns a value LSL to extTyp which for a value of 64
-      // bits, is the same as UXTX
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
-      if (CurInst->getOpcode() == AArch64::STRBBroX) {
-        assert(shiftAmtVal == 0 &&
-               "AArch64::STRBBroX shift amount (5th operand) "
-               "is always 0");
-      }
+      shiftAmt = 0;
+      break;
+    case AArch64::STRHHroX:
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
+      extTyp = extendTypeVal ? SXTX : UXTX;
+      shiftAmt = shiftAmtVal ? 1 : 0;
+      break;
+    case AArch64::STRWroX:
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
+      extTyp = extendTypeVal ? SXTX : UXTX;
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::STRXroX:
-      // The manual assigns a value LSL to extTyp which for a value of 64
-      // bits, is the same as UXTX
+      // The manual assigns a value LSL to extTyp if extendTypeVal is 1
+      // which for a value of 64 bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
@@ -3798,6 +3819,8 @@ public:
     }
     case AArch64::LDRBBroW:
     case AArch64::LDRBBroX:
+    case AArch64::LDRHHroW:
+    case AArch64::LDRHHroX:
     case AArch64::LDRWroW:
     case AArch64::LDRWroX:
     case AArch64::LDRXroW:
@@ -3808,6 +3831,10 @@ public:
       case AArch64::LDRBBroW:
       case AArch64::LDRBBroX:
         size = 1;
+        break;
+      case AArch64::LDRHHroW:
+      case AArch64::LDRHHroX:
+        size = 2;
         break;
       case AArch64::LDRWroX:
       case AArch64::LDRWroW:
@@ -3900,6 +3927,8 @@ public:
     }
     case AArch64::STRBBroW:
     case AArch64::STRBBroX:
+    case AArch64::STRHHroW:
+    case AArch64::STRHHroX:
     case AArch64::STRWroW:
     case AArch64::STRWroX:
     case AArch64::STRXroW:
@@ -3910,6 +3939,10 @@ public:
       case AArch64::STRBBroW:
       case AArch64::STRBBroX:
         storeToMemoryValOffset(base, offset, 1, createTrunc(val, i8));
+        break;
+      case AArch64::STRHHroW:
+      case AArch64::STRHHroX:
+        storeToMemoryValOffset(base, offset, 2, createTrunc(val, i16));
         break;
       case AArch64::STRWroW:
       case AArch64::STRWroX:

--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -304,37 +304,38 @@ class arm2llvm {
   };
 
   const set<int> instrs_32 = {
-      AArch64::ADDWrx,    AArch64::ADDSWrs,    AArch64::ADDSWri,
-      AArch64::ADDWrs,    AArch64::ADDWri,     AArch64::ADDSWrx,
-      AArch64::ADCWr,     AArch64::ADCSWr,     AArch64::ASRVWr,
-      AArch64::SUBWri,    AArch64::SUBWrs,     AArch64::SUBWrx,
-      AArch64::SUBSWrs,   AArch64::SUBSWri,    AArch64::SUBSWrx,
-      AArch64::SBFMWri,   AArch64::CSELWr,     AArch64::ANDWri,
-      AArch64::ANDWrr,    AArch64::ANDWrs,     AArch64::ANDSWri,
-      AArch64::ANDSWrr,   AArch64::ANDSWrs,    AArch64::MADDWrrr,
-      AArch64::MSUBWrrr,  AArch64::EORWri,     AArch64::CSINVWr,
-      AArch64::CSINCWr,   AArch64::MOVZWi,     AArch64::MOVNWi,
-      AArch64::MOVKWi,    AArch64::LSLVWr,     AArch64::LSRVWr,
-      AArch64::ORNWrs,    AArch64::UBFMWri,    AArch64::BFMWri,
-      AArch64::ORRWrs,    AArch64::ORRWri,     AArch64::SDIVWr,
-      AArch64::UDIVWr,    AArch64::EXTRWrri,   AArch64::EORWrs,
-      AArch64::RORVWr,    AArch64::RBITWr,     AArch64::CLZWr,
-      AArch64::REVWr,     AArch64::CSNEGWr,    AArch64::BICWrs,
-      AArch64::BICSWrs,   AArch64::EONWrs,     AArch64::REV16Wr,
-      AArch64::Bcc,       AArch64::CCMPWr,     AArch64::CCMPWi,
-      AArch64::LDRWui,    AArch64::LDRWroW,    AArch64::LDRWroX,
-      AArch64::LDRSui,    AArch64::LDRBBui,    AArch64::LDRBui,
-      AArch64::LDRSBWui,  AArch64::LDRSWui,    AArch64::LDRSHWui,
-      AArch64::LDRSBWui,  AArch64::LDRHHui,    AArch64::LDRHui,
-      AArch64::STRWui,    AArch64::STRWroW,    AArch64::STRWroX,
-      AArch64::CCMNWi,    AArch64::CCMNWr,     AArch64::STRBBui,
-      AArch64::STRBui,    AArch64::STPWi,      AArch64::STRHHui,
-      AArch64::STRHui,    AArch64::STURWi,     AArch64::STRSui,
-      AArch64::LDPWi,     AArch64::STRWpre,    AArch64::FADDSrr,
-      AArch64::FSUBSrr,   AArch64::FCMPSrr,    AArch64::FCMPSri,
-      AArch64::FMOVSWr,   AArch64::INSvi32gpr, AArch64::INSvi16gpr,
-      AArch64::INSvi8gpr, AArch64::FCVTSHr,    AArch64::FCVTZSUWSr,
-      AArch64::FCSELSrrr, AArch64::FMULSrr,    AArch64::FABSSr,
+      AArch64::ADDWrx,     AArch64::ADDSWrs,    AArch64::ADDSWri,
+      AArch64::ADDWrs,     AArch64::ADDWri,     AArch64::ADDSWrx,
+      AArch64::ADCWr,      AArch64::ADCSWr,     AArch64::ASRVWr,
+      AArch64::SUBWri,     AArch64::SUBWrs,     AArch64::SUBWrx,
+      AArch64::SUBSWrs,    AArch64::SUBSWri,    AArch64::SUBSWrx,
+      AArch64::SBFMWri,    AArch64::CSELWr,     AArch64::ANDWri,
+      AArch64::ANDWrr,     AArch64::ANDWrs,     AArch64::ANDSWri,
+      AArch64::ANDSWrr,    AArch64::ANDSWrs,    AArch64::MADDWrrr,
+      AArch64::MSUBWrrr,   AArch64::EORWri,     AArch64::CSINVWr,
+      AArch64::CSINCWr,    AArch64::MOVZWi,     AArch64::MOVNWi,
+      AArch64::MOVKWi,     AArch64::LSLVWr,     AArch64::LSRVWr,
+      AArch64::ORNWrs,     AArch64::UBFMWri,    AArch64::BFMWri,
+      AArch64::ORRWrs,     AArch64::ORRWri,     AArch64::SDIVWr,
+      AArch64::UDIVWr,     AArch64::EXTRWrri,   AArch64::EORWrs,
+      AArch64::RORVWr,     AArch64::RBITWr,     AArch64::CLZWr,
+      AArch64::REVWr,      AArch64::CSNEGWr,    AArch64::BICWrs,
+      AArch64::BICSWrs,    AArch64::EONWrs,     AArch64::REV16Wr,
+      AArch64::Bcc,        AArch64::CCMPWr,     AArch64::CCMPWi,
+      AArch64::LDRWui,     AArch64::LDRBBroW,   AArch64::LDRBBroX,
+      AArch64::LDRWroW,    AArch64::LDRWroX,    AArch64::LDRSui,
+      AArch64::LDRBBui,    AArch64::LDRBui,     AArch64::LDRSBWui,
+      AArch64::LDRSWui,    AArch64::LDRSHWui,   AArch64::LDRSBWui,
+      AArch64::LDRHHui,    AArch64::LDRHui,     AArch64::STRWui,
+      AArch64::STRWroW,    AArch64::STRWroX,    AArch64::CCMNWi,
+      AArch64::CCMNWr,     AArch64::STRBBui,    AArch64::STRBui,
+      AArch64::STPWi,      AArch64::STRHHui,    AArch64::STRHui,
+      AArch64::STURWi,     AArch64::STRSui,     AArch64::LDPWi,
+      AArch64::STRWpre,    AArch64::FADDSrr,    AArch64::FSUBSrr,
+      AArch64::FCMPSrr,    AArch64::FCMPSri,    AArch64::FMOVSWr,
+      AArch64::INSvi32gpr, AArch64::INSvi16gpr, AArch64::INSvi8gpr,
+      AArch64::FCVTSHr,    AArch64::FCVTZSUWSr, AArch64::FCSELSrrr,
+      AArch64::FMULSrr,    AArch64::FABSSr,
   };
 
   const set<int> instrs_64 = {
@@ -1766,18 +1767,30 @@ public:
 
     int extTyp, shiftAmt;
     switch (CurInst->getOpcode()) {
+    case AArch64::LDRBBroW:
     case AArch64::LDRWroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
+      if (CurInst->getOpcode() == AArch64::LDRBBroW) {
+        assert(shiftAmtVal == 0 &&
+               "AArch64::LDRBBroW shift amount (5th operand) "
+               "is always 0");
+      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::LDRXroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
+    case AArch64::LDRBBroX:
     case AArch64::LDRWroX:
       // The manual assigns a value LSL to extTyp which for a value of 64
       // bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
+      if (CurInst->getOpcode() == AArch64::LDRBBroX) {
+        assert(shiftAmtVal == 0 &&
+               "AArch64::LDRBBroX shift amount (5th operand) "
+               "is always 0");
+      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::LDRXroX:
@@ -3770,6 +3783,8 @@ public:
       updateReg(added, ptrReg);
       break;
     }
+    case AArch64::LDRBBroW:
+    case AArch64::LDRBBroX:
     case AArch64::LDRWroW:
     case AArch64::LDRWroX:
     case AArch64::LDRXroW:
@@ -3777,6 +3792,10 @@ public:
       unsigned size;
 
       switch (opcode) {
+      case AArch64::LDRBBroW:
+      case AArch64::LDRBBroX:
+        size = 1;
+        break;
       case AArch64::LDRWroX:
       case AArch64::LDRWroW:
         size = 4;

--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -304,38 +304,39 @@ class arm2llvm {
   };
 
   const set<int> instrs_32 = {
-      AArch64::ADDWrx,     AArch64::ADDSWrs,    AArch64::ADDSWri,
-      AArch64::ADDWrs,     AArch64::ADDWri,     AArch64::ADDSWrx,
-      AArch64::ADCWr,      AArch64::ADCSWr,     AArch64::ASRVWr,
-      AArch64::SUBWri,     AArch64::SUBWrs,     AArch64::SUBWrx,
-      AArch64::SUBSWrs,    AArch64::SUBSWri,    AArch64::SUBSWrx,
-      AArch64::SBFMWri,    AArch64::CSELWr,     AArch64::ANDWri,
-      AArch64::ANDWrr,     AArch64::ANDWrs,     AArch64::ANDSWri,
-      AArch64::ANDSWrr,    AArch64::ANDSWrs,    AArch64::MADDWrrr,
-      AArch64::MSUBWrrr,   AArch64::EORWri,     AArch64::CSINVWr,
-      AArch64::CSINCWr,    AArch64::MOVZWi,     AArch64::MOVNWi,
-      AArch64::MOVKWi,     AArch64::LSLVWr,     AArch64::LSRVWr,
-      AArch64::ORNWrs,     AArch64::UBFMWri,    AArch64::BFMWri,
-      AArch64::ORRWrs,     AArch64::ORRWri,     AArch64::SDIVWr,
-      AArch64::UDIVWr,     AArch64::EXTRWrri,   AArch64::EORWrs,
-      AArch64::RORVWr,     AArch64::RBITWr,     AArch64::CLZWr,
-      AArch64::REVWr,      AArch64::CSNEGWr,    AArch64::BICWrs,
-      AArch64::BICSWrs,    AArch64::EONWrs,     AArch64::REV16Wr,
-      AArch64::Bcc,        AArch64::CCMPWr,     AArch64::CCMPWi,
-      AArch64::LDRWui,     AArch64::LDRBBroW,   AArch64::LDRBBroX,
-      AArch64::LDRWroW,    AArch64::LDRWroX,    AArch64::LDRSui,
-      AArch64::LDRBBui,    AArch64::LDRBui,     AArch64::LDRSBWui,
-      AArch64::LDRSWui,    AArch64::LDRSHWui,   AArch64::LDRSBWui,
-      AArch64::LDRHHui,    AArch64::LDRHui,     AArch64::STRWui,
-      AArch64::STRWroW,    AArch64::STRWroX,    AArch64::CCMNWi,
-      AArch64::CCMNWr,     AArch64::STRBBui,    AArch64::STRBui,
-      AArch64::STPWi,      AArch64::STRHHui,    AArch64::STRHui,
-      AArch64::STURWi,     AArch64::STRSui,     AArch64::LDPWi,
-      AArch64::STRWpre,    AArch64::FADDSrr,    AArch64::FSUBSrr,
-      AArch64::FCMPSrr,    AArch64::FCMPSri,    AArch64::FMOVSWr,
-      AArch64::INSvi32gpr, AArch64::INSvi16gpr, AArch64::INSvi8gpr,
-      AArch64::FCVTSHr,    AArch64::FCVTZSUWSr, AArch64::FCSELSrrr,
-      AArch64::FMULSrr,    AArch64::FABSSr,
+      AArch64::ADDWrx,     AArch64::ADDSWrs,   AArch64::ADDSWri,
+      AArch64::ADDWrs,     AArch64::ADDWri,    AArch64::ADDSWrx,
+      AArch64::ADCWr,      AArch64::ADCSWr,    AArch64::ASRVWr,
+      AArch64::SUBWri,     AArch64::SUBWrs,    AArch64::SUBWrx,
+      AArch64::SUBSWrs,    AArch64::SUBSWri,   AArch64::SUBSWrx,
+      AArch64::SBFMWri,    AArch64::CSELWr,    AArch64::ANDWri,
+      AArch64::ANDWrr,     AArch64::ANDWrs,    AArch64::ANDSWri,
+      AArch64::ANDSWrr,    AArch64::ANDSWrs,   AArch64::MADDWrrr,
+      AArch64::MSUBWrrr,   AArch64::EORWri,    AArch64::CSINVWr,
+      AArch64::CSINCWr,    AArch64::MOVZWi,    AArch64::MOVNWi,
+      AArch64::MOVKWi,     AArch64::LSLVWr,    AArch64::LSRVWr,
+      AArch64::ORNWrs,     AArch64::UBFMWri,   AArch64::BFMWri,
+      AArch64::ORRWrs,     AArch64::ORRWri,    AArch64::SDIVWr,
+      AArch64::UDIVWr,     AArch64::EXTRWrri,  AArch64::EORWrs,
+      AArch64::RORVWr,     AArch64::RBITWr,    AArch64::CLZWr,
+      AArch64::REVWr,      AArch64::CSNEGWr,   AArch64::BICWrs,
+      AArch64::BICSWrs,    AArch64::EONWrs,    AArch64::REV16Wr,
+      AArch64::Bcc,        AArch64::CCMPWr,    AArch64::CCMPWi,
+      AArch64::LDRWui,     AArch64::LDRBBroW,  AArch64::LDRBBroX,
+      AArch64::LDRWroW,    AArch64::LDRWroX,   AArch64::LDRSui,
+      AArch64::LDRBBui,    AArch64::LDRBui,    AArch64::LDRSBWui,
+      AArch64::LDRSWui,    AArch64::LDRSHWui,  AArch64::LDRSBWui,
+      AArch64::LDRHHui,    AArch64::LDRHui,    AArch64::STRWui,
+      AArch64::STRBBroW,   AArch64::STRBBroX,  AArch64::STRWroW,
+      AArch64::STRWroX,    AArch64::CCMNWi,    AArch64::CCMNWr,
+      AArch64::STRBBui,    AArch64::STRBui,    AArch64::STPWi,
+      AArch64::STRHHui,    AArch64::STRHui,    AArch64::STURWi,
+      AArch64::STRSui,     AArch64::LDPWi,     AArch64::STRWpre,
+      AArch64::FADDSrr,    AArch64::FSUBSrr,   AArch64::FCMPSrr,
+      AArch64::FCMPSri,    AArch64::FMOVSWr,   AArch64::INSvi32gpr,
+      AArch64::INSvi16gpr, AArch64::INSvi8gpr, AArch64::FCVTSHr,
+      AArch64::FCVTZSUWSr, AArch64::FCSELSrrr, AArch64::FMULSrr,
+      AArch64::FABSSr,
   };
 
   const set<int> instrs_64 = {
@@ -1872,18 +1873,30 @@ public:
 
     int extTyp, shiftAmt;
     switch (CurInst->getOpcode()) {
+    case AArch64::STRBBroW:
     case AArch64::STRWroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
+      if (CurInst->getOpcode() == AArch64::STRBBroW) {
+        assert(shiftAmtVal == 0 &&
+               "AArch64::STRBBroW shift amount (5th operand) "
+               "is always 0");
+      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::STRXroW:
       extTyp = extendTypeVal ? SXTW : UXTW;
       shiftAmt = shiftAmtVal ? 3 : 0;
       break;
+    case AArch64::STRBBroX:
     case AArch64::STRWroX:
       // The manual assigns a value LSL to extTyp which for a value of 64
       // bits, is the same as UXTX
       extTyp = extendTypeVal ? SXTX : UXTX;
+      if (CurInst->getOpcode() == AArch64::STRBBroX) {
+        assert(shiftAmtVal == 0 &&
+               "AArch64::STRBBroX shift amount (5th operand) "
+               "is always 0");
+      }
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::STRXroX:
@@ -3885,6 +3898,8 @@ public:
       storeToMemoryImmOffset(shiftedPtr, 0, 8, valToStore);
       break;
     }
+    case AArch64::STRBBroW:
+    case AArch64::STRBBroX:
     case AArch64::STRWroW:
     case AArch64::STRWroX:
     case AArch64::STRXroW:
@@ -3892,6 +3907,10 @@ public:
       auto [base, offset, val] = getParamsStoreReg();
 
       switch (opcode) {
+      case AArch64::STRBBroW:
+      case AArch64::STRBBroX:
+        storeToMemoryValOffset(base, offset, 1, createTrunc(val, i8));
+        break;
       case AArch64::STRWroW:
       case AArch64::STRWroX:
         storeToMemoryValOffset(base, offset, 4, createTrunc(val, i32));
@@ -4580,13 +4599,9 @@ public:
       // If the global has not been created yet, create it
       auto name = srcFnGlobal.getName();
       if (globals[name.str()] == nullptr) {
-        // Gets 2nd argument to ArrayType::get from the size in bytes of the
-        // source global value
-        auto *AT = ArrayType::get(
-            i8, srcFnGlobal.getValueType()->getPrimitiveSizeInBits() / 8);
-        auto *g = new GlobalVariable(*LiftedModule, AT, false,
-                                     GlobalValue::LinkageTypes::ExternalLinkage,
-                                     nullptr, name);
+        auto *g = new GlobalVariable(
+            *LiftedModule, srcFnGlobal.getValueType(), false,
+            GlobalValue::LinkageTypes::ExternalLinkage, nullptr, name);
         g->setAlignment(MaybeAlign(16));
         globals[srcFnGlobal.getName().str()] = g;
       }

--- a/tests/arm-tv/mem-ops/LDRBBroWwithExtend.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRBBroWwithExtend.aarch64.ll
@@ -1,0 +1,10 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define i32 @test_load_extract_from_mul_4(ptr %0, i32 %1) {
+  %3 = mul i32 %1, 510136
+  %4 = getelementptr inbounds i8, ptr %0, i32 %3
+  %5 = load i8, ptr %4, align 1
+  %6 = zext i8 %5 to i32
+  ret i32 %6
+}

--- a/tests/arm-tv/mem-ops/LDRBBroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRBBroX.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define dso_local zeroext i32 @ld_align64_uint32_t_uint8_t(ptr nocapture readonly %0) {
+  %2 = getelementptr inbounds i8, ptr %0, i64 1000000000000
+  %3 = load i8, ptr %2, align 1
+  %4 = zext i8 %3 to i32
+  ret i32 %4
+}

--- a/tests/arm-tv/mem-ops/LDRHHroWwithExtendShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRHHroWwithExtendShift.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define zeroext i16 @load_R_h_(ptr nocapture readonly %0, i32 %1) local_unnamed_addr {
+  %3 = sext i32 %1 to i64
+  %4 = getelementptr inbounds i16, ptr %0, i64 %3
+  %5 = load i16, ptr %4, align 2
+  ret i16 %5
+}

--- a/tests/arm-tv/mem-ops/LDRHHroXwithShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRHHroXwithShift.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+; Function Attrs: nounwind
+define i16 @extractelt_v16i16_idx(ptr %0, i32 zeroext %1) {
+  %3 = load <16 x i16>, ptr %0, align 32
+  %4 = extractelement <16 x i16> %3, i32 %1
+  ret i16 %4
+}

--- a/tests/arm-tv/mem-ops/STRBBroWwithExtend.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRBBroWwithExtend.aarch64.ll
@@ -1,0 +1,12 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+@ga = external global [1024 x i8], align 8
+
+; Function Attrs: nounwind
+define void @test11(i32 %0, i8 signext %1) {
+  %3 = shl nsw i32 %0, 1
+  %4 = getelementptr inbounds [1024 x i8], ptr @ga, i32 0, i32 %3
+  store i8 %1, ptr %4, align 1
+  ret void
+}

--- a/tests/arm-tv/mem-ops/STRBBroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRBBroX.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define dso_local void @st_align64_uint32_t_uint8_t(ptr nocapture %0, i32 zeroext %1) {
+  %3 = trunc i32 %1 to i8
+  %4 = getelementptr inbounds i8, ptr %0, i64 1000000000000
+  store i8 %3, ptr %4, align 1
+  ret void
+}

--- a/tests/arm-tv/mem-ops/STRHHroWwithExtendShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRHHroWwithExtendShift.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define zeroext i16 @store_R_h_(ptr %0, i32 %1, i16 %2) local_unnamed_addr {
+  %4 = sext i32 %1 to i64
+  %5 = getelementptr inbounds i16, ptr %0, i64 %4
+  store i16 %2, ptr %5, align 2
+  ret i16 0
+}

--- a/tests/arm-tv/mem-ops/STRHHroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRHHroX.aarch64.ll
@@ -1,0 +1,9 @@
+; ModuleID = '<stdin>'
+source_filename = "<stdin>"
+
+define dso_local void @st_align32_uint64_t_int16_t(ptr nocapture %0, i64 %1) {
+  %3 = trunc i64 %1 to i16
+  %4 = getelementptr inbounds i8, ptr %0, i64 99999000
+  store i16 %3, ptr %4, align 2
+  ret void
+}


### PR DESCRIPTION
Added support for and tests for LDRH (LDRHHroW and LDRHHBroX)
Added support for and tests for STRH (STRHHroW and STHHBroX)
Added support for and tests for STRB (STRBBroW and STRBBroX)
Added support for and tests for LDRB (LDRBBroW and LDRBBroX)
Fixed a bug wherein the global created had the wrong type. One of the tests included in this commit caught it.
Cleaned up extendAndShiftValue so isSigned becomes more intuitive.
clang-formatted using clang-17