### PR TITLE
Added support and tests for ld1r  (LD1Rv1d not supported due to absense of test case)

### DIFF
--- a/tests/arm-tv/mem-ops/LD1Rv16b(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv16b(no_offset).aarch64.ll
@@ -1,0 +1,6 @@
+define <16 x i8> @vecucuc(ptr nocapture readonly %0) {
+  %2 = load i8, ptr %0, align 1
+  %3 = insertelement <16 x i8> undef, i8 %2, i32 0
+  %4 = shufflevector <16 x i8> %3, <16 x i8> undef, <16 x i32> zeroinitializer
+  ret <16 x i8> %4
+}

--- a/tests/arm-tv/mem-ops/LD1Rv2d(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv2d(no_offset).aarch64.ll
@@ -1,0 +1,6 @@
+define <2 x i64> @load_splat_v2i64_a4(ptr %0) {
+  %2 = load i64, ptr %0, align 4
+  %3 = insertelement <2 x i64> undef, i64 %2, i32 0
+  %4 = shufflevector <2 x i64> %3, <2 x i64> undef, <2 x i32> zeroinitializer
+  ret <2 x i64> %4
+}

--- a/tests/arm-tv/mem-ops/LD1Rv2s(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv2s(no_offset).aarch64.ll
@@ -1,0 +1,6 @@
+define <2 x i32> @ld1r_2s_int_shuff(ptr nocapture %0) {
+  %2 = load i32, ptr %0, align 4
+  %3 = insertelement <2 x i32> undef, i32 %2, i32 0
+  %4 = shufflevector <2 x i32> %3, <2 x i32> undef, <2 x i32> zeroinitializer
+  ret <2 x i32> %4
+}

--- a/tests/arm-tv/mem-ops/LD1Rv4h(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv4h(no_offset).aarch64.ll
@@ -1,0 +1,5 @@
+define <4 x i16> @shuffle3(ptr %0) {
+  %2 = load <4 x i16>, ptr %0, align 8
+  %3 = shufflevector <4 x i16> %2, <4 x i16> undef, <4 x i32> zeroinitializer
+  ret <4 x i16> %3
+}

--- a/tests/arm-tv/mem-ops/LD1Rv4s(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv4s(no_offset).aarch64.ll
@@ -1,0 +1,6 @@
+define <4 x i32> @load_splat_v4i32_a2(ptr %0) {
+  %2 = load i32, ptr %0, align 2
+  %3 = insertelement <4 x i32> undef, i32 %2, i32 0
+  %4 = shufflevector <4 x i32> %3, <4 x i32> undef, <4 x i32> zeroinitializer
+  ret <4 x i32> %4
+}

--- a/tests/arm-tv/mem-ops/LD1Rv8b(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv8b(no_offset).aarch64.ll
@@ -1,0 +1,7 @@
+define <8 x i8> @dup_ld1_from_stack(ptr %0) {
+  %2 = alloca i8, align 1
+  %3 = load i8, ptr %2, align 1
+  %4 = insertelement <8 x i8> poison, i8 %3, i32 0
+  %5 = shufflevector <8 x i8> %4, <8 x i8> %4, <8 x i32> zeroinitializer
+  ret <8 x i8> %5
+}

--- a/tests/arm-tv/mem-ops/LD1Rv8h(no_offset).aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1Rv8h(no_offset).aarch64.ll
@@ -1,0 +1,5 @@
+define <8 x i16> @f5(ptr %0) {
+  %2 = load i16, ptr %0, align 2
+  %3 = insertelement <8 x i16> undef, i16 %2, i32 3
+  ret <8 x i16> %3
+}

--- a/tests/arm-tv/mem-ops/LD1i16.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1i16.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <8 x i16> @load_lane_i16_a2(ptr %0, <8 x i16> %1) {
   %3 = load i16, ptr %0, align 2
   %4 = insertelement <8 x i16> %1, i16 %3, i32 0

--- a/tests/arm-tv/mem-ops/LD1i32.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1i32.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <4 x i32> @pinsrd_from_shufflevector_i32(<4 x i32> %0, ptr nocapture readonly %1) {
   %3 = load <4 x i32>, ptr %1, align 16
   %4 = shufflevector <4 x i32> %0, <4 x i32> %3, <4 x i32> <i32 0, i32 1, i32 2, i32 4>

--- a/tests/arm-tv/mem-ops/LD1i64.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1i64.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <2 x i64> @s2v_test4(ptr nocapture readonly %0, <2 x i64> %1) {
   %3 = getelementptr inbounds i64, ptr %0, i64 1
   %4 = load i64, ptr %3, align 8

--- a/tests/arm-tv/mem-ops/LD1i8.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LD1i8.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <16 x i8> @f2(<16 x i8> %0, ptr %1) {
   %3 = load i8, ptr %1, align 1
   %4 = insertelement <16 x i8> %0, i8 %3, i32 15

--- a/tests/arm-tv/mem-ops/LDRBBroWwithExtend.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRBBroWwithExtend.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define i32 @test_load_extract_from_mul_4(ptr %0, i32 %1) {
   %3 = mul i32 %1, 510136
   %4 = getelementptr inbounds i8, ptr %0, i32 %3

--- a/tests/arm-tv/mem-ops/LDRBBroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRBBroX.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define dso_local zeroext i32 @ld_align64_uint32_t_uint8_t(ptr nocapture readonly %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 1000000000000
   %3 = load i8, ptr %2, align 1

--- a/tests/arm-tv/mem-ops/LDRHHroWwithExtendShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRHHroWwithExtendShift.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define zeroext i16 @load_R_h_(ptr nocapture readonly %0, i32 %1) local_unnamed_addr {
   %3 = sext i32 %1 to i64
   %4 = getelementptr inbounds i16, ptr %0, i64 %3

--- a/tests/arm-tv/mem-ops/LDRHHroXwithShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRHHroXwithShift.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: nounwind
 define i16 @extractelt_v16i16_idx(ptr %0, i32 zeroext %1) {
   %3 = load <16 x i16>, ptr %0, align 32

--- a/tests/arm-tv/mem-ops/LDRQroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRQroX.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 @GlobLd128 = external dso_local local_unnamed_addr global [20 x fp128], align 16
 @GlobSt128 = external dso_local local_unnamed_addr global [20 x fp128], align 16
 

--- a/tests/arm-tv/mem-ops/LDURBBi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURBBi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define i8 @test25(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i32 -128
   %3 = load i8, ptr %2, align 1

--- a/tests/arm-tv/mem-ops/LDURBi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURBi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <16 x i8> @loadv16i8_noffset(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 -1
   %3 = load i8, ptr %2, align 1

--- a/tests/arm-tv/mem-ops/LDURDi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURDi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: nounwind ssp memory(read)
 define <4 x i16> @fct2(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 3

--- a/tests/arm-tv/mem-ops/LDURHHi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURHHi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: nounwind memory(read)
 define zeroext i16 @t6(ptr nocapture %0) {
   %2 = getelementptr inbounds i16, ptr %0, i32 -128

--- a/tests/arm-tv/mem-ops/LDURHi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURHi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <4 x i16> @loadv4i16_offset(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 1
   %3 = load i16, ptr %2, align 2

--- a/tests/arm-tv/mem-ops/LDURQi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURQi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: nounwind ssp memory(read)
 define <16 x i8> @fct7(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 3

--- a/tests/arm-tv/mem-ops/LDURSi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURSi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define <2 x i32> @loadv2i32_offset(ptr %0) {
   %2 = getelementptr inbounds i8, ptr %0, i64 1
   %3 = load i32, ptr %2, align 4

--- a/tests/arm-tv/mem-ops/LDURXi.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDURXi.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: sspstrong
 define i64 @bitcast_larger_load() {
   %1 = alloca i32, align 4
@@ -8,9 +5,3 @@ define i64 @bitcast_larger_load() {
   %2 = load i64, ptr %1, align 4
   ret i64 %2
 }
-
-
-
-!llvm.module.flags = !{!0}
-
-!0 = !{i32 7, !"direct-access-external-data", i32 1}

--- a/tests/arm-tv/mem-ops/ST1i16.aarch64.ll
+++ b/tests/arm-tv/mem-ops/ST1i16.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define void @extract_store_i16_2(<8 x i16> %0, ptr %1) {
   %3 = extractelement <8 x i16> %0, i32 2
   store i16 %3, ptr %1, align 2

--- a/tests/arm-tv/mem-ops/ST1i32.aarch64.ll
+++ b/tests/arm-tv/mem-ops/ST1i32.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define void @f14(<4 x i32> %0, ptr %1) {
   %3 = extractelement <4 x i32> %0, i32 3
   store i32 %3, ptr %1, align 4

--- a/tests/arm-tv/mem-ops/ST1i64.aarch64.ll
+++ b/tests/arm-tv/mem-ops/ST1i64.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 ; Function Attrs: nounwind
 define void @extract_i64_1(ptr nocapture %0, <2 x i64> %1) {
   %3 = extractelement <2 x i64> %1, i32 1

--- a/tests/arm-tv/mem-ops/ST1i8.aarch64.ll
+++ b/tests/arm-tv/mem-ops/ST1i8.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define void @storevcsc7(<16 x i8> %0, ptr nocapture %1) {
   %3 = extractelement <16 x i8> %0, i32 7
   store i8 %3, ptr %1, align 1

--- a/tests/arm-tv/mem-ops/STRBBroWwithExtend.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRBBroWwithExtend.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 @ga = external global [1024 x i8], align 8
 
 ; Function Attrs: nounwind

--- a/tests/arm-tv/mem-ops/STRBBroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRBBroX.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define dso_local void @st_align64_uint32_t_uint8_t(ptr nocapture %0, i32 zeroext %1) {
   %3 = trunc i32 %1 to i8
   %4 = getelementptr inbounds i8, ptr %0, i64 1000000000000

--- a/tests/arm-tv/mem-ops/STRHHroWwithExtendShift.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRHHroWwithExtendShift.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define zeroext i16 @store_R_h_(ptr %0, i32 %1, i16 %2) local_unnamed_addr {
   %4 = sext i32 %1 to i64
   %5 = getelementptr inbounds i16, ptr %0, i64 %4

--- a/tests/arm-tv/mem-ops/STRHHroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRHHroX.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define dso_local void @st_align32_uint64_t_int16_t(ptr nocapture %0, i64 %1) {
   %3 = trunc i64 %1 to i16
   %4 = getelementptr inbounds i8, ptr %0, i64 99999000

--- a/tests/arm-tv/mem-ops/STRQroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/STRQroX.aarch64.ll
@@ -1,6 +1,3 @@
-; ModuleID = '<stdin>'
-source_filename = "<stdin>"
-
 define dso_local void @st_reg_vector(ptr nocapture %0, i64 %1, <16 x i8> %2) {
   %4 = getelementptr inbounds i8, ptr %0, i64 %1
   store <16 x i8> %2, ptr %4, align 16


### PR DESCRIPTION
Cleaned up tests
Added support and tests for ld1r (no offset) [LD1Rv8b, LD1Rv16b, LD1Rv4h, LD1Rv8h, LD1Rv2s, LD1Rv4s, LD1Rv2d] (Notice LD1Rv1d not supported due to absense of test case)