### PR TITLE
Add support for `LDRSB (register)`, `LDRSH (register)`, and `LDRSW (register)`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -334,36 +334,39 @@ class arm2llvm {
       AArch64::REV16Wr,    AArch64::Bcc,        AArch64::CCMPWr,
       AArch64::CCMPWi,     AArch64::LDRWui,     AArch64::LDRBBroW,
       AArch64::LDRBBroX,   AArch64::LDRHHroW,   AArch64::LDRHHroX,
-      AArch64::LDRWroW,    AArch64::LDRWroX,    AArch64::LDRSui,
-      AArch64::LDRBBui,    AArch64::LDRBui,     AArch64::LDRSBWui,
-      AArch64::LDRSWui,    AArch64::LDRSHWui,   AArch64::LDRHHui,
-      AArch64::LDRHui,     AArch64::LDURBi,     AArch64::LDURBBi,
-      AArch64::LDURHi,     AArch64::LDURHHi,    AArch64::LDURSi,
-      AArch64::LDURWi,     AArch64::LDRBBpre,   AArch64::LDRBpre,
-      AArch64::LDRHHpre,   AArch64::LDRHpre,    AArch64::LDRWpre,
-      AArch64::LDRSpre,    AArch64::LDRBBpost,  AArch64::LDRBpost,
-      AArch64::LDRHHpost,  AArch64::LDRHpost,   AArch64::LDRWpost,
-      AArch64::LDRSpost,   AArch64::STRBBpost,  AArch64::STRBpost,
-      AArch64::STRHHpost,  AArch64::STRHpost,   AArch64::STRWpost,
-      AArch64::STRSpost,   AArch64::STRWui,     AArch64::STRBBroW,
-      AArch64::STRBBroX,   AArch64::STRHHroW,   AArch64::STRHHroX,
-      AArch64::STRWroW,    AArch64::STRWroX,    AArch64::CCMNWi,
-      AArch64::CCMNWr,     AArch64::STRBBui,    AArch64::STRBui,
-      AArch64::STPWi,      AArch64::STPSi,      AArch64::STPWpre,
-      AArch64::STPSpre,    AArch64::STPWpost,   AArch64::STPSpost,
-      AArch64::STRHHui,    AArch64::STRHui,     AArch64::STURBBi,
-      AArch64::STURBi,     AArch64::STURHHi,    AArch64::STURHi,
-      AArch64::STURWi,     AArch64::STURSi,     AArch64::STRSui,
-      AArch64::LDPWi,      AArch64::LDPSi,      AArch64::LDPWpre,
-      AArch64::LDPSpre,    AArch64::LDPWpost,   AArch64::LDPSpost,
-      AArch64::STRBBpre,   AArch64::STRBpre,    AArch64::STRHHpre,
-      AArch64::STRHpre,    AArch64::STRWpre,    AArch64::STRSpre,
-      AArch64::FADDSrr,    AArch64::FSUBSrr,    AArch64::FCMPSrr,
-      AArch64::FCMPSri,    AArch64::FMOVSWr,    AArch64::INSvi32gpr,
-      AArch64::INSvi16gpr, AArch64::INSvi8gpr,  AArch64::FCVTSHr,
-      AArch64::FCVTZSUWSr, AArch64::FCSELSrrr,  AArch64::FMULSrr,
-      AArch64::FABSSr,     AArch64::UQADDv1i32, AArch64::SQSUBv1i32,
-      AArch64::SQADDv1i32,
+      AArch64::LDRWroW,    AArch64::LDRWroX,    AArch64::LDRSBWroW,
+      AArch64::LDRSBWroX,  AArch64::LDRSBXroW,  AArch64::LDRSBXroX,
+      AArch64::LDRSHWroW,  AArch64::LDRSHWroX,  AArch64::LDRSHXroW,
+      AArch64::LDRSHXroX,  AArch64::LDRSWroW,   AArch64::LDRSWroX,
+      AArch64::LDRSui,     AArch64::LDRBBui,    AArch64::LDRBui,
+      AArch64::LDRSBWui,   AArch64::LDRSWui,    AArch64::LDRSHWui,
+      AArch64::LDRHHui,    AArch64::LDRHui,     AArch64::LDURBi,
+      AArch64::LDURBBi,    AArch64::LDURHi,     AArch64::LDURHHi,
+      AArch64::LDURSi,     AArch64::LDURWi,     AArch64::LDRBBpre,
+      AArch64::LDRBpre,    AArch64::LDRHHpre,   AArch64::LDRHpre,
+      AArch64::LDRWpre,    AArch64::LDRSpre,    AArch64::LDRBBpost,
+      AArch64::LDRBpost,   AArch64::LDRHHpost,  AArch64::LDRHpost,
+      AArch64::LDRWpost,   AArch64::LDRSpost,   AArch64::STRBBpost,
+      AArch64::STRBpost,   AArch64::STRHHpost,  AArch64::STRHpost,
+      AArch64::STRWpost,   AArch64::STRSpost,   AArch64::STRWui,
+      AArch64::STRBBroW,   AArch64::STRBBroX,   AArch64::STRHHroW,
+      AArch64::STRHHroX,   AArch64::STRWroW,    AArch64::STRWroX,
+      AArch64::CCMNWi,     AArch64::CCMNWr,     AArch64::STRBBui,
+      AArch64::STRBui,     AArch64::STPWi,      AArch64::STPSi,
+      AArch64::STPWpre,    AArch64::STPSpre,    AArch64::STPWpost,
+      AArch64::STPSpost,   AArch64::STRHHui,    AArch64::STRHui,
+      AArch64::STURBBi,    AArch64::STURBi,     AArch64::STURHHi,
+      AArch64::STURHi,     AArch64::STURWi,     AArch64::STURSi,
+      AArch64::STRSui,     AArch64::LDPWi,      AArch64::LDPSi,
+      AArch64::LDPWpre,    AArch64::LDPSpre,    AArch64::LDPWpost,
+      AArch64::LDPSpost,   AArch64::STRBBpre,   AArch64::STRBpre,
+      AArch64::STRHHpre,   AArch64::STRHpre,    AArch64::STRWpre,
+      AArch64::STRSpre,    AArch64::FADDSrr,    AArch64::FSUBSrr,
+      AArch64::FCMPSrr,    AArch64::FCMPSri,    AArch64::FMOVSWr,
+      AArch64::INSvi32gpr, AArch64::INSvi16gpr, AArch64::INSvi8gpr,
+      AArch64::FCVTSHr,    AArch64::FCVTZSUWSr, AArch64::FCSELSrrr,
+      AArch64::FMULSrr,    AArch64::FABSSr,     AArch64::UQADDv1i32,
+      AArch64::SQSUBv1i32, AArch64::SQADDv1i32,
   };
 
   const set<int> instrs_64 = {
@@ -2252,16 +2255,26 @@ public:
     switch (CurInst->getOpcode()) {
     case AArch64::LDRBBroW:
     case AArch64::LDRBBroX:
+    case AArch64::LDRSBWroW:
+    case AArch64::LDRSBWroX:
+    case AArch64::LDRSBXroW:
+    case AArch64::LDRSBXroX:
       shiftAmt = 0;
       break;
     case AArch64::LDRHHroW:
     case AArch64::LDRHHroX:
+    case AArch64::LDRSHWroW:
+    case AArch64::LDRSHWroX:
+    case AArch64::LDRSHXroW:
+    case AArch64::LDRSHXroX:
       shiftAmt = shiftAmtVal ? 1 : 0;
       break;
     case AArch64::LDRWroW:
     case AArch64::LDRWroX:
     case AArch64::LDRSroW:
     case AArch64::LDRSroX:
+    case AArch64::LDRSWroW:
+    case AArch64::LDRSWroX:
       shiftAmt = shiftAmtVal ? 2 : 0;
       break;
     case AArch64::LDRXroW:
@@ -3935,22 +3948,42 @@ public:
     case AArch64::LDRDroW:
     case AArch64::LDRDroX:
     case AArch64::LDRQroW:
-    case AArch64::LDRQroX: {
+    case AArch64::LDRQroX:
+    case AArch64::LDRSBWroW:
+    case AArch64::LDRSBWroX:
+    case AArch64::LDRSBXroW:
+    case AArch64::LDRSBXroX:
+    case AArch64::LDRSHWroW:
+    case AArch64::LDRSHWroX:
+    case AArch64::LDRSHXroW:
+    case AArch64::LDRSHXroX:
+    case AArch64::LDRSWroW:
+    case AArch64::LDRSWroX: {
       unsigned size;
 
       switch (opcode) {
       case AArch64::LDRBBroW:
       case AArch64::LDRBBroX:
+      case AArch64::LDRSBWroW:
+      case AArch64::LDRSBWroX:
+      case AArch64::LDRSBXroW:
+      case AArch64::LDRSBXroX:
         size = 1;
         break;
       case AArch64::LDRHHroW:
       case AArch64::LDRHHroX:
+      case AArch64::LDRSHWroW:
+      case AArch64::LDRSHWroX:
+      case AArch64::LDRSHXroW:
+      case AArch64::LDRSHXroX:
         size = 2;
         break;
       case AArch64::LDRWroX:
       case AArch64::LDRWroW:
       case AArch64::LDRSroW:
       case AArch64::LDRSroX:
+      case AArch64::LDRSWroW:
+      case AArch64::LDRSWroX:
         size = 4;
         break;
       case AArch64::LDRXroW:
@@ -3969,9 +4002,16 @@ public:
         break;
       }
 
+      bool sExt =
+          opcode == AArch64::LDRSBWroW || opcode == AArch64::LDRSBWroX ||
+          opcode == AArch64::LDRSBXroW || opcode == AArch64::LDRSBXroX ||
+          opcode == AArch64::LDRSHWroW || opcode == AArch64::LDRSHWroX ||
+          opcode == AArch64::LDRSHXroW || opcode == AArch64::LDRSHXroX ||
+          opcode == AArch64::LDRSWroW || opcode == AArch64::LDRSWroX;
+
       auto [base, offset] = getParamsLoadReg();
       auto loaded = makeLoadWithOffset(base, offset, size);
-      updateOutputReg(loaded);
+      updateOutputReg(loaded, sExt);
       break;
     }
 

--- a/tests/arm-tv/mem-ops/LDRSBWroW.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSBWroW.aarch64.ll
@@ -1,0 +1,8 @@
+@ga = external global [1024 x i8], align 8
+
+; Function Attrs: nounwind memory(read)
+define signext i8 @f(i32 %0) {
+  %2 = getelementptr inbounds [1024 x i8], ptr @ga, i32 0, i32 %0
+  %3 = load i8, ptr %2, align 1
+  ret i8 %3
+}

--- a/tests/arm-tv/mem-ops/LDRSBWroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSBWroX.aarch64.ll
@@ -1,0 +1,6 @@
+define dso_local signext i32 @f(ptr nocapture readonly %0) {
+  %2 = getelementptr inbounds i8, ptr %0, i64 99999000
+  %3 = load i8, ptr %2, align 1
+  %4 = sext i8 %3 to i32
+  ret i32 %4
+}

--- a/tests/arm-tv/mem-ops/LDRSBXroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSBXroX.aarch64.ll
@@ -1,0 +1,6 @@
+define dso_local i64 @f(ptr nocapture readonly %0) {
+  %2 = getelementptr inbounds i8, ptr %0, i64 99999000
+  %3 = load i8, ptr %2, align 1
+  %4 = sext i8 %3 to i64
+  ret i64 %4
+}

--- a/tests/arm-tv/mem-ops/LDRSHWroW.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSHWroW.aarch64.ll
@@ -1,0 +1,6 @@
+define i32 @f(ptr %0, i32 %1) {
+  %3 = getelementptr inbounds i16, ptr %0, i32 %1
+  %4 = load i16, ptr %3, align 2
+  %5 = sext i16 %4 to i32
+  ret i32 %5
+}

--- a/tests/arm-tv/mem-ops/LDRSHWroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSHWroX.aarch64.ll
@@ -1,0 +1,6 @@
+define dso_local signext i16 @f(ptr nocapture readonly %0) {
+  %2 = getelementptr inbounds i8, ptr %0, i64 99999000
+  %3 = load i64, ptr %2, align 8
+  %4 = trunc i64 %3 to i16
+  ret i16 %4
+}

--- a/tests/arm-tv/mem-ops/LDRSHXroW.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSHXroW.aarch64.ll
@@ -1,0 +1,12 @@
+define dso_local i32 @f(ptr %0, i32 %1) {
+  %3 = sext i32 %1 to i64
+  %4 = getelementptr inbounds i16, ptr %0, i64 %3
+  %5 = load i16, ptr %4, align 2
+  %6 = load i16, ptr %4, align 4
+  %7 = sext i16 %5 to i64
+  %8 = getelementptr inbounds i64, ptr %0, i64 %7
+  %9 = load i64, ptr %8, align 16
+  %10 = load i64, ptr %8, align 32
+  %11 = trunc i64 %9 to i32
+  ret i32 %11
+}

--- a/tests/arm-tv/mem-ops/LDRSHXroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSHXroX.aarch64.ll
@@ -1,0 +1,6 @@
+define dso_local i64 @f(ptr nocapture readonly %0) {
+  %2 = getelementptr inbounds i8, ptr %0, i64 99999
+  %3 = load i16, ptr %2, align 2
+  %4 = sext i16 %3 to i64
+  ret i64 %4
+}

--- a/tests/arm-tv/mem-ops/LDRSWroW.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSWroW.aarch64.ll
@@ -1,0 +1,8 @@
+define <2 x i64> @f(ptr nocapture readonly %0, <2 x i64> %1, i32 signext %2) {
+  %4 = sext i32 %2 to i64
+  %5 = getelementptr inbounds i32, ptr %0, i64 %4
+  %6 = load i32, ptr %5, align 4
+  %7 = sext i32 %6 to i64
+  %8 = insertelement <2 x i64> %1, i64 %7, i32 0
+  ret <2 x i64> %8
+}

--- a/tests/arm-tv/mem-ops/LDRSWroX.aarch64.ll
+++ b/tests/arm-tv/mem-ops/LDRSWroX.aarch64.ll
@@ -1,0 +1,6 @@
+define i64 @f(ptr %0) {
+  %2 = getelementptr inbounds i32, ptr %0, i64 1039992
+  %3 = load i32, ptr %2, align 2
+  %4 = sext i32 %3 to i64
+  ret i64 %4
+}


### PR DESCRIPTION
Add support for `LDRSB (register)`, `LDRSH (register)`, and `LDRSW (register)`