### PR TITLE
Added support for `SMLAL (vector)`

### DIFF
--- a/tests/arm-tv/vectors/smlal/SMLALv2i32_v2i64.aarch64.ll
+++ b/tests/arm-tv/vectors/smlal/SMLALv2i32_v2i64.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define <2 x i64> @f(<2 x i64> %0, <2 x i32> %1, <2 x i32> %2) {
+  %4 = zext <2 x i32> %1 to <2 x i64>
+  %5 = zext <2 x i32> %2 to <2 x i64>
+  %6 = mul <2 x i64> %4, %5
+  %7 = add <2 x i64> %0, %6
+  %8 = and <2 x i64> %7, <i64 4294967295, i64 4294967295>
+  ret <2 x i64> %8
+}

--- a/tests/arm-tv/vectors/smlal/SMLALv4i16_v4i32.aarch64.ll
+++ b/tests/arm-tv/vectors/smlal/SMLALv4i16_v4i32.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define <4 x i32> @f(<4 x i32> %0, <4 x i16> %1, <4 x i16> %2) {
+  %4 = zext <4 x i16> %1 to <4 x i32>
+  %5 = zext <4 x i16> %2 to <4 x i32>
+  %6 = mul <4 x i32> %4, %5
+  %7 = add <4 x i32> %0, %6
+  %8 = and <4 x i32> %7, <i32 65535, i32 65535, i32 65535, i32 65535>
+  ret <4 x i32> %8
+}

--- a/tests/arm-tv/vectors/smlal/SMLALv8i16_v4i32.aarch64.ll
+++ b/tests/arm-tv/vectors/smlal/SMLALv8i16_v4i32.aarch64.ll
@@ -1,0 +1,12 @@
+define i32 @f(ptr %0, ptr %1) {
+  %3 = load <8 x i16>, ptr %0, align 2
+  %4 = sext <8 x i16> %3 to <8 x i32>
+  %5 = load <8 x i16>, ptr %1, align 2
+  %6 = sext <8 x i16> %5 to <8 x i32>
+  %7 = mul nsw <8 x i32> %6, %4
+  %8 = call i32 @llvm.vector.reduce.add.v8i32(<8 x i32> %7)
+  ret i32 %8
+}
+
+; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
+declare i32 @llvm.vector.reduce.add.v8i32(<8 x i32>) #0

--- a/tests/arm-tv/vectors/smlal/SMLALv8i8_v8i16.aarch64.ll
+++ b/tests/arm-tv/vectors/smlal/SMLALv8i8_v8i16.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define <8 x i16> @f(<8 x i16> %0, <8 x i8> %1, <8 x i8> %2) {
+  %4 = zext <8 x i8> %1 to <8 x i16>
+  %5 = zext <8 x i8> %2 to <8 x i16>
+  %6 = mul <8 x i16> %4, %5
+  %7 = add <8 x i16> %0, %6
+  %8 = and <8 x i16> %7, <i16 255, i16 255, i16 255, i16 255, i16 255, i16 255, i16 255, i16 255>
+  ret <8 x i16> %8
+}


### PR DESCRIPTION
Added support for `SMLAL (vector)`
Added commented code for `UMLAL (by element)` and `SMLAL (by element)` due to lack of tests and removed the initial incomplete commented code.
Fixed an int to unsigned int narrowing warning.