### PR TITLE
Added support for `UMLSL (vector)` and `SMLSL (vector)`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -735,6 +735,16 @@ class arm2llvm {
       AArch64::UMLALv16i8_v8i16,
       AArch64::UMLALv8i16_v4i32,
       AArch64::UMLALv4i32_v2i64,
+      AArch64::UMLSLv4i16_indexed,
+      AArch64::UMLSLv8i16_indexed,
+      AArch64::UMLSLv2i32_indexed,
+      AArch64::UMLSLv4i32_indexed,
+      AArch64::UMLSLv8i8_v8i16,
+      AArch64::UMLSLv4i16_v4i32,
+      AArch64::UMLSLv2i32_v2i64,
+      AArch64::UMLSLv16i8_v8i16,
+      AArch64::UMLSLv8i16_v4i32,
+      AArch64::UMLSLv4i32_v2i64,
       AArch64::SMLALv4i16_indexed,
       AArch64::SMLALv8i16_indexed,
       AArch64::SMLALv2i32_indexed,
@@ -745,8 +755,16 @@ class arm2llvm {
       AArch64::SMLALv16i8_v8i16,
       AArch64::SMLALv8i16_v4i32,
       AArch64::SMLALv4i32_v2i64,
-      AArch64::SMLALv4i32_indexed,
-      AArch64::SMLALv8i16_indexed,
+      AArch64::SMLSLv4i16_indexed,
+      AArch64::SMLSLv8i16_indexed,
+      AArch64::SMLSLv2i32_indexed,
+      AArch64::SMLSLv4i32_indexed,
+      AArch64::SMLSLv8i8_v8i16,
+      AArch64::SMLSLv4i16_v4i32,
+      AArch64::SMLSLv2i32_v2i64,
+      AArch64::SMLSLv16i8_v8i16,
+      AArch64::SMLSLv8i16_v4i32,
+      AArch64::SMLSLv4i32_v2i64,
       AArch64::SQADDv2i64,
       AArch64::SQADDv4i32,
       AArch64::SQADDv16i8,
@@ -6886,49 +6904,82 @@ public:
       break;
     }
 
-      /*
-      case AArch64::UMLALv4i16_indexed:
-      case AArch64::UMLALv8i16_indexed:
-      case AArch64::UMLALv2i32_indexed:
-      case AArch64::UMLALv4i32_indexed:
-      case AArch64::SMLALv4i16_indexed:
-      case AArch64::SMLALv8i16_indexed:
-      case AArch64::SMLALv2i32_indexed:
-      case AArch64::SMLALv4i32_indexed: {
-        unsigned numElts, eltSize;
-        GET_SIZES4(SMLAL, _indexed);
-        auto isUpper = opcode == AArch64::UMLALv8i16_indexed || opcode ==
-      AArch64::SMLALv8i16_indexed || opcode == AArch64::UMLALv4i32_indexed ||
-      opcode == AArch64::SMLALv4i32_indexed; auto isSigned = opcode ==
-      AArch64::SMLALv4i16_indexed || opcode == AArch64::SMLALv8i16_indexed ||
-                        opcode == AArch64::SMLALv2i32_indexed || opcode ==
-      AArch64::SMLALv4i32_indexed; assert(isSIMDandFPReg(CurInst->getOperand(0))
-      && isSIMDandFPReg(CurInst->getOperand(1)) &&
-               CurInst->getOperand(0).getReg() ==
-                   CurInst->getOperand(1).getReg());
-        assert(CurInst->getOperand(4).isImm());
+    /*
+    case AArch64::UMLALv4i16_indexed:
+    case AArch64::UMLALv8i16_indexed:
+    case AArch64::UMLALv2i32_indexed:
+    case AArch64::UMLALv4i32_indexed:
+    case AArch64::UMLSLv4i16_indexed:
+    case AArch64::UMLSLv8i16_indexed:
+    case AArch64::UMLSLv2i32_indexed:
+    case AArch64::UMLSLv4i32_indexed:
+    case AArch64::SMLALv4i16_indexed:
+    case AArch64::SMLALv8i16_indexed:
+    case AArch64::SMLALv2i32_indexed:
+    case AArch64::SMLALv4i32_indexed:
+    case AArch64::SMLSLv4i16_indexed:
+    case AArch64::SMLSLv8i16_indexed:
+    case AArch64::SMLSLv2i32_indexed:
+    case AArch64::SMLSLv4i32_indexed: {
+      unsigned numElts, eltSize;
+      GET_SIZES4(SMLAL, _indexed);
+      auto isUpper = opcode == AArch64::UMLALv8i16_indexed ||
+                     opcode == AArch64::UMLSLv8i16_indexed ||
+                     opcode == AArch64::SMLALv8i16_indexed ||
+                     opcode == AArch64::SMLSLv8i16_indexed ||
+                     opcode == AArch64::UMLALv4i32_indexed ||
+                     opcode == AArch64::UMLSLv4i32_indexed ||
+                     opcode == AArch64::SMLALv4i32_indexed ||
+                     opcode == AArch64::SMLSLv4i32_indexed;
+      auto isSigned = opcode == AArch64::SMLALv4i16_indexed ||
+                      opcode == AArch64::SMLSLv4i16_indexed ||
+                      opcode == AArch64::SMLALv8i16_indexed ||
+                      opcode == AArch64::SMLSLv8i16_indexed ||
+                      opcode == AArch64::SMLALv2i32_indexed ||
+                      opcode == AArch64::SMLSLv2i32_indexed ||
+                      opcode == AArch64::SMLALv4i32_indexed ||
+                      opcode == AArch64::SMLSLv4i32_indexed;
+      auto isSub = opcode == AArch64::UMLSLv4i16_indexed ||
+                   opcode == AArch64::UMLSLv8i16_indexed ||
+                   opcode == AArch64::UMLSLv2i32_indexed ||
+                   opcode == AArch64::UMLSLv4i32_indexed ||
+                   opcode == AArch64::SMLSLv4i16_indexed ||
+                   opcode == AArch64::SMLSLv8i16_indexed ||
+                   opcode == AArch64::SMLSLv2i32_indexed ||
+                   opcode == AArch64::SMLSLv4i32_indexed;
+      assert(isSIMDandFPReg(CurInst->getOperand(0)) &&
+             isSIMDandFPReg(CurInst->getOperand(1)) &&
+             CurInst->getOperand(0).getReg() ==
+                 CurInst->getOperand(1).getReg());
+      assert(CurInst->getOperand(4).isImm());
 
-        auto destReg = readFromVecOperand(1, 2 * eltSize, isUpper ? numElts / 2
-      : numElts); auto a = readFromVecOperand(2, eltSize, numElts, isUpper);
-        auto element = getIndexedElement(getImm(4), eltSize,
-                                    CurInst->getOperand(3).getReg());
-        auto splatElement = splat(element, numElts, eltSize);
+      auto destReg =
+          readFromVecOperand(1, 2 * eltSize, isUpper ? numElts / 2 : numElts);
+      auto a = readFromVecOperand(2, eltSize, numElts, isUpper);
+      auto element = getIndexedElement(getImm(4), eltSize,
+                                       CurInst->getOperand(3).getReg());
+      auto splatElement = splat(element, numElts, eltSize);
 
-        auto extended_a = isSigned?
-                                   createSExt(a, getVecTy(2 * eltSize, isUpper ?
-      numElts / 2 : numElts)) : createZExt(a, getVecTy(2 * eltSize, isUpper ?
-      numElts / 2 : numElts)); auto extended_b = isSigned?
-                                   createSExt(splatElement, getVecTy(2 *
-      eltSize, isUpper ? numElts / 2 : numElts)) : createZExt(splatElement,
-      getVecTy(2 * eltSize, isUpper ? numElts / 2 : numElts));
+      auto extended_a =
+          isSigned ? createSExt(a, getVecTy(2 * eltSize,
+                                            isUpper ? numElts / 2 : numElts))
+                   : createZExt(a, getVecTy(2 * eltSize,
+                                            isUpper ? numElts / 2 : numElts));
+      auto extended_b =
+          isSigned ? createSExt(
+                         splatElement,
+                         getVecTy(2 * eltSize, isUpper ? numElts / 2 : numElts))
+                   : createZExt(splatElement,
+                                getVecTy(2 * eltSize,
+                                         isUpper ? numElts / 2 : numElts));
 
-        auto mul = createMul(extended_a, extended_b);
-        auto sum = createAdd(mul, destReg);
+      auto mul = createMul(extended_a, extended_b);
+      auto sum = isSub ? createSub(destReg, mul) : createAdd(destReg, mul);
 
-        updateOutputReg(sum);
-        break;
-      }
-      */
+      updateOutputReg(sum);
+      break;
+    }
+    */
 
     case AArch64::UMLALv8i8_v8i16:
     case AArch64::UMLALv16i8_v8i16:
@@ -6936,41 +6987,65 @@ public:
     case AArch64::UMLALv8i16_v4i32:
     case AArch64::UMLALv2i32_v2i64:
     case AArch64::UMLALv4i32_v2i64:
+    case AArch64::UMLSLv8i8_v8i16:
+    case AArch64::UMLSLv16i8_v8i16:
+    case AArch64::UMLSLv4i16_v4i32:
+    case AArch64::UMLSLv8i16_v4i32:
+    case AArch64::UMLSLv2i32_v2i64:
+    case AArch64::UMLSLv4i32_v2i64:
     case AArch64::SMLALv8i8_v8i16:
     case AArch64::SMLALv16i8_v8i16:
     case AArch64::SMLALv4i16_v4i32:
     case AArch64::SMLALv8i16_v4i32:
     case AArch64::SMLALv2i32_v2i64:
-    case AArch64::SMLALv4i32_v2i64: {
+    case AArch64::SMLALv4i32_v2i64:
+    case AArch64::SMLSLv8i8_v8i16:
+    case AArch64::SMLSLv16i8_v8i16:
+    case AArch64::SMLSLv4i16_v4i32:
+    case AArch64::SMLSLv8i16_v4i32:
+    case AArch64::SMLSLv2i32_v2i64:
+    case AArch64::SMLSLv4i32_v2i64: {
       unsigned numElts, eltSize;
       switch (opcode) {
       case AArch64::UMLALv8i8_v8i16:
+      case AArch64::UMLSLv8i8_v8i16:
       case AArch64::SMLALv8i8_v8i16:
+      case AArch64::SMLSLv8i8_v8i16:
         numElts = 8;
         eltSize = 8;
         break;
       case AArch64::UMLALv16i8_v8i16:
+      case AArch64::UMLSLv16i8_v8i16:
       case AArch64::SMLALv16i8_v8i16:
+      case AArch64::SMLSLv16i8_v8i16:
         numElts = 16;
         eltSize = 8;
         break;
       case AArch64::UMLALv4i16_v4i32:
+      case AArch64::UMLSLv4i16_v4i32:
       case AArch64::SMLALv4i16_v4i32:
+      case AArch64::SMLSLv4i16_v4i32:
         numElts = 4;
         eltSize = 16;
         break;
       case AArch64::UMLALv8i16_v4i32:
+      case AArch64::UMLSLv8i16_v4i32:
       case AArch64::SMLALv8i16_v4i32:
+      case AArch64::SMLSLv8i16_v4i32:
         numElts = 8;
         eltSize = 16;
         break;
       case AArch64::UMLALv2i32_v2i64:
+      case AArch64::UMLSLv2i32_v2i64:
       case AArch64::SMLALv2i32_v2i64:
+      case AArch64::SMLSLv2i32_v2i64:
         numElts = 2;
         eltSize = 32;
         break;
       case AArch64::UMLALv4i32_v2i64:
+      case AArch64::UMLSLv4i32_v2i64:
       case AArch64::SMLALv4i32_v2i64:
+      case AArch64::SMLSLv4i32_v2i64:
         numElts = 4;
         eltSize = 32;
         break;
@@ -6978,17 +7053,41 @@ public:
         assert(false);
       }
       auto isUpper = opcode == AArch64::UMLALv16i8_v8i16 ||
+                     opcode == AArch64::UMLSLv16i8_v8i16 ||
                      opcode == AArch64::SMLALv16i8_v8i16 ||
+                     opcode == AArch64::SMLSLv16i8_v8i16 ||
                      opcode == AArch64::UMLALv8i16_v4i32 ||
+                     opcode == AArch64::UMLSLv8i16_v4i32 ||
                      opcode == AArch64::SMLALv8i16_v4i32 ||
+                     opcode == AArch64::SMLSLv8i16_v4i32 ||
                      opcode == AArch64::UMLALv4i32_v2i64 ||
-                     opcode == AArch64::SMLALv4i32_v2i64;
+                     opcode == AArch64::UMLSLv4i32_v2i64 ||
+                     opcode == AArch64::SMLALv4i32_v2i64 ||
+                     opcode == AArch64::SMLSLv4i32_v2i64;
       auto isSigned = opcode == AArch64::SMLALv8i8_v8i16 ||
+                      opcode == AArch64::SMLSLv8i8_v8i16 ||
                       opcode == AArch64::SMLALv16i8_v8i16 ||
+                      opcode == AArch64::SMLSLv16i8_v8i16 ||
                       opcode == AArch64::SMLALv4i16_v4i32 ||
+                      opcode == AArch64::SMLSLv4i16_v4i32 ||
                       opcode == AArch64::SMLALv8i16_v4i32 ||
+                      opcode == AArch64::SMLSLv8i16_v4i32 ||
                       opcode == AArch64::SMLALv2i32_v2i64 ||
-                      opcode == AArch64::SMLALv4i32_v2i64;
+                      opcode == AArch64::SMLSLv2i32_v2i64 ||
+                      opcode == AArch64::SMLALv4i32_v2i64 ||
+                      opcode == AArch64::SMLSLv4i32_v2i64;
+      auto isSub = opcode == AArch64::UMLSLv8i8_v8i16 ||
+                   opcode == AArch64::UMLSLv16i8_v8i16 ||
+                   opcode == AArch64::UMLSLv4i16_v4i32 ||
+                   opcode == AArch64::UMLSLv8i16_v4i32 ||
+                   opcode == AArch64::UMLSLv2i32_v2i64 ||
+                   opcode == AArch64::UMLSLv4i32_v2i64 ||
+                   opcode == AArch64::SMLSLv8i8_v8i16 ||
+                   opcode == AArch64::SMLSLv16i8_v8i16 ||
+                   opcode == AArch64::SMLSLv4i16_v4i32 ||
+                   opcode == AArch64::SMLSLv8i16_v4i32 ||
+                   opcode == AArch64::SMLSLv2i32_v2i64 ||
+                   opcode == AArch64::SMLSLv4i32_v2i64;
       assert(isSIMDandFPReg(CurInst->getOperand(0)) &&
              isSIMDandFPReg(CurInst->getOperand(1)) &&
              CurInst->getOperand(0).getReg() ==
@@ -7010,7 +7109,7 @@ public:
                                             isUpper ? numElts / 2 : numElts));
 
       auto mul = createMul(extended_a, extended_b);
-      auto sum = createAdd(mul, destReg);
+      auto sum = isSub ? createSub(destReg, mul) : createAdd(destReg, mul);
 
       updateOutputReg(sum);
       break;

--- a/tests/arm-tv/vectors/smlsl/SMLSLv2i32_v2i64.aarch64.ll
+++ b/tests/arm-tv/vectors/smlsl/SMLSLv2i32_v2i64.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define <2 x i64> @f(<2 x i64> %0, <2 x i32> %1, <2 x i32> %2) {
+  %4 = zext <2 x i32> %1 to <2 x i64>
+  %5 = zext <2 x i32> %2 to <2 x i64>
+  %6 = mul <2 x i64> %4, %5
+  %7 = sub <2 x i64> %0, %6
+  %8 = and <2 x i64> %7, <i64 4294967295, i64 4294967295>
+  ret <2 x i64> %8
+}

--- a/tests/arm-tv/vectors/smlsl/SMLSLv4i16_v4i32.aarch64.ll
+++ b/tests/arm-tv/vectors/smlsl/SMLSLv4i16_v4i32.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define <4 x i32> @f(<4 x i32> %0, <4 x i16> %1, <4 x i16> %2) {
+  %4 = zext <4 x i16> %1 to <4 x i32>
+  %5 = zext <4 x i16> %2 to <4 x i32>
+  %6 = mul <4 x i32> %4, %5
+  %7 = sub <4 x i32> %0, %6
+  %8 = and <4 x i32> %7, <i32 65535, i32 65535, i32 65535, i32 65535>
+  ret <4 x i32> %8
+}

--- a/tests/arm-tv/vectors/smlsl/SMLSLv8i8_v8i16.aarch64.ll
+++ b/tests/arm-tv/vectors/smlsl/SMLSLv8i8_v8i16.aarch64.ll
@@ -1,0 +1,11 @@
+define <8 x i16> @f(<8 x i16> %0, <8 x i8> %1, <8 x i8> %2, <8 x i8> %3, <8 x i8> %4) {
+  %6 = sext <8 x i8> %1 to <8 x i16>
+  %7 = sext <8 x i8> %2 to <8 x i16>
+  %8 = sext <8 x i8> %3 to <8 x i16>
+  %9 = sext <8 x i8> %4 to <8 x i16>
+  %10 = mul nsw <8 x i16> %7, %6
+  %11 = mul nsw <8 x i16> %9, %8
+  %12 = add <8 x i16> %11, %10
+  %13 = sub <8 x i16> %0, %12
+  ret <8 x i16> %13
+}

--- a/tests/arm-tv/vectors/umlsl/UMLSLv2i32_v2i64.aarch64.ll
+++ b/tests/arm-tv/vectors/umlsl/UMLSLv2i32_v2i64.aarch64.ll
@@ -1,0 +1,8 @@
+; Function Attrs: nounwind
+define <2 x i64> @f(<2 x i64> %0, <2 x i32> %1, <2 x i32> %2) {
+  %4 = zext <2 x i32> %1 to <2 x i64>
+  %5 = zext <2 x i32> %2 to <2 x i64>
+  %6 = mul <2 x i64> %4, %5
+  %7 = sub <2 x i64> %0, %6
+  ret <2 x i64> %7
+}

--- a/tests/arm-tv/vectors/umlsl/UMLSLv4i16_v4i32.aarch64.ll
+++ b/tests/arm-tv/vectors/umlsl/UMLSLv4i16_v4i32.aarch64.ll
@@ -1,0 +1,8 @@
+; Function Attrs: nounwind
+define <4 x i32> @f(<4 x i32> %0, <4 x i16> %1, <4 x i16> %2) {
+  %4 = zext <4 x i16> %1 to <4 x i32>
+  %5 = zext <4 x i16> %2 to <4 x i32>
+  %6 = mul <4 x i32> %4, %5
+  %7 = sub <4 x i32> %0, %6
+  ret <4 x i32> %7
+}

--- a/tests/arm-tv/vectors/umlsl/UMLSLv8i8_v8i16.aarch64.ll
+++ b/tests/arm-tv/vectors/umlsl/UMLSLv8i8_v8i16.aarch64.ll
@@ -1,0 +1,8 @@
+; Function Attrs: nounwind
+define <8 x i16> @f(<8 x i16> %0, <8 x i8> %1, <8 x i8> %2) {
+  %4 = zext <8 x i8> %1 to <8 x i16>
+  %5 = zext <8 x i8> %2 to <8 x i16>
+  %6 = mul <8 x i16> %4, %5
+  %7 = sub <8 x i16> %0, %6
+  ret <8 x i16> %7
+}


### PR DESCRIPTION
Added support for `UMLSL (vector)` and `SMLSL (vector)`
Added tests for half the variants
Added coommented code for `UMLSL (by element)` and `SMLSL (by element)` due to lack of tests without NEON intrinsics.