### PR TITLE
Added support for `SCVTF (scalar, integer)`

### DIFF
--- a/tests/arm-tv/vectors/scvtf/SCVTFUWDri.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFUWDri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define ptr @_ZN11xercesc_2_722XMLAbstractDoubleFloatC2EPNS_13MemoryManagerE() #0 {
+entry:
+  %conv = tail call double @llvm.experimental.constrained.sitofp.f64.i32(i32 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret ptr null
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.sitofp.f64.i32(i32, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/scvtf/SCVTFUWSri.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFUWSri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define void @_ZN11xercesc_2_78XMLFloat13checkBoundaryEPc() #0 {
+entry:
+  %conv2 = tail call float @llvm.experimental.constrained.sitofp.f32.i32(i32 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.sitofp.f32.i32(i32, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/scvtf/SCVTFUXDri.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFUXDri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define i32 @S_sv_ncmp() #0 {
+entry:
+  %conv = tail call double @llvm.experimental.constrained.sitofp.f64.i64(i64 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret i32 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.sitofp.f64.i64(i64, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/scvtf/SCVTFUXSri.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFUXSri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define void @initialize_particle() #0 {
+entry:
+  %conv = tail call float @llvm.experimental.constrained.sitofp.f32.i64(i64 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.sitofp.f32.i64(i64, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }


### PR DESCRIPTION
Added support for `SCVTF (scalar, integer)`
Not added support for the half precision variants due to lack of tests