### PR TITLE
Added support for `UCVTF (scalar, integer)`

### DIFF
--- a/tests/arm-tv/vectors/ucvtf/UCVTFUWDri.aarch64.ll
+++ b/tests/arm-tv/vectors/ucvtf/UCVTFUWDri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define double @_ZNK11xalanc_1_108XBoolean12stringLengthEv() #0 {
+entry:
+  %conv3 = tail call double @llvm.experimental.constrained.uitofp.f64.i32(i32 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret double 0.000000e+00
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.uitofp.f64.i32(i32, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/ucvtf/UCVTFUWSri.aarch64.ll
+++ b/tests/arm-tv/vectors/ucvtf/UCVTFUWSri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define void @rgb_uchar_to_float() #0 {
+entry:
+  %conv = tail call float @llvm.experimental.constrained.uitofp.f32.i8(i8 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.uitofp.f32.i8(i8, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/ucvtf/UCVTFUXDri.aarch64.ll
+++ b/tests/arm-tv/vectors/ucvtf/UCVTFUXDri.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.uitofp.f64.i64(i64, metadata, metadata) #0
+
+; Function Attrs: strictfp
+define double @spec_genrand_res53() #1 {
+entry:
+  %conv = tail call double @llvm.experimental.constrained.uitofp.f64.i64(i64 0, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
+  ret double 0.000000e+00
+}
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
+attributes #1 = { strictfp }


### PR DESCRIPTION
Added support for `UCVTF (scalar, integer)`
Not added support for the half precision variants due to lack of tests