### PR TITLE
Bug fix - UCVTF

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -5958,15 +5958,16 @@ public:
     case AArch64::SCVTFUWDri:
     case AArch64::SCVTFUXSri:
     case AArch64::SCVTFUXDri: {
+      auto &op0 = CurInst->getOperand(0);
       auto &op1 = CurInst->getOperand(1);
-      assert(op1.isReg());
+      assert(op0.isReg() && op1.isReg());
 
       auto isSigned =
           opcode == AArch64::SCVTFUWSri || opcode == AArch64::SCVTFUWDri ||
           opcode == AArch64::SCVTFUXSri || opcode == AArch64::SCVTFUXDri;
 
-      auto fTy = getFPType(getRegSize(op1.getReg()));
-      auto val = readFromReg(op1.getReg());
+      auto fTy = getFPType(getRegSize(op0.getReg()));
+      auto val = readFromOperand(1, getRegSize(op1.getReg()));
       auto converted =
           isSigned ? createSIToFP(val, fTy) : createUIToFP(val, fTy);
 

--- a/tests/arm-tv/vectors/ucvtf/UCVTFUWDri_2.aarch64.ll
+++ b/tests/arm-tv/vectors/ucvtf/UCVTFUWDri_2.aarch64.ll
@@ -1,0 +1,12 @@
+; Function Attrs: strictfp
+define double @_ZNK11xalanc_1_107XString12stringLengthEv() #0 {
+entry:
+  %conv = tail call double @llvm.experimental.constrained.uitofp.f64.i32(i32 1, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  ret double %conv
+}
+
+; Function Attrs: nocallback nofree nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.uitofp.f64.i32(i32, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind strictfp willreturn memory(inaccessiblemem: readwrite) }


### PR DESCRIPTION
Bug fix - Was converting to the incorrect floating point type. The type to be converted to depends on the destination register and not source.
Another incorrect implementation - readFromReg does a full-width read. Replaced it with readFromOperand