### PR TITLE
Added support for `FCVTZS (scalar, integer)`

### DIFF
--- a/tests/arm-tv/fp/fcmp/FCMPESri.aarch64.ll
+++ b/tests/arm-tv/fp/fcmp/FCMPESri.aarch64.ll
@@ -1,0 +1,20 @@
+; Function Attrs: strictfp
+define void @ptcache_particle_interpolate() #0 {
+entry:
+  %conv = tail call i32 @llvm.experimental.constrained.fptosi.i32.f32(float 0.000000e+00, metadata !"fpexcept.strict") #0
+  %conv1 = tail call float @llvm.experimental.constrained.sitofp.f32.i32(i32 %conv, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  %cmp3 = tail call i1 @llvm.experimental.constrained.fcmps.f32(float %conv1, float 0.000000e+00, metadata !"olt", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.sitofp.f32.i32(i32, metadata, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i32 @llvm.experimental.constrained.fptosi.i32.f32(float, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i1 @llvm.experimental.constrained.fcmps.f32(float, float, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/fcvtzs/FCVTZSv1i32.aarch64.ll
+++ b/tests/arm-tv/vectors/fcvtzs/FCVTZSv1i32.aarch64.ll
@@ -1,0 +1,20 @@
+; Function Attrs: strictfp
+define void @ptcache_particle_interpolate() #0 {
+entry:
+  %conv = tail call i32 @llvm.experimental.constrained.fptosi.i32.f32(float 0.000000e+00, metadata !"fpexcept.strict") #0
+  %conv1 = tail call float @llvm.experimental.constrained.sitofp.f32.i32(i32 %conv, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  %cmp3 = tail call i1 @llvm.experimental.constrained.fcmps.f32(float %conv1, float 0.000000e+00, metadata !"olt", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.sitofp.f32.i32(i32, metadata, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i32 @llvm.experimental.constrained.fptosi.i32.f32(float, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i1 @llvm.experimental.constrained.fcmps.f32(float, float, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/fcvtzs/FCVTZSv1i64.aarch64.ll
+++ b/tests/arm-tv/vectors/fcvtzs/FCVTZSv1i64.aarch64.ll
@@ -1,0 +1,20 @@
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i1 @llvm.experimental.constrained.fcmp.f64(double, double, metadata, metadata) #0
+
+; Function Attrs: strictfp
+define double @_ZN11xalanc_1_1013DoubleSupport7modulusEdd() #1 {
+entry:
+  %conv10 = tail call i64 @llvm.experimental.constrained.fptosi.i64.f64(double 0.000000e+00, metadata !"fpexcept.strict") #1
+  %conv11 = tail call double @llvm.experimental.constrained.sitofp.f64.i64(i64 %conv10, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
+  %cmp12 = tail call i1 @llvm.experimental.constrained.fcmp.f64(double %conv11, double 0.000000e+00, metadata !"oeq", metadata !"fpexcept.strict") #1
+  ret double 0.000000e+00
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i64 @llvm.experimental.constrained.fptosi.i64.f64(double, metadata) #0
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.sitofp.f64.i64(i64, metadata, metadata) #0
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
+attributes #1 = { strictfp }

--- a/tests/arm-tv/vectors/scvtf/SCVTFv1i32.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFv1i32.aarch64.ll
@@ -1,0 +1,20 @@
+; Function Attrs: strictfp
+define void @ptcache_particle_interpolate() #0 {
+entry:
+  %conv = tail call i32 @llvm.experimental.constrained.fptosi.i32.f32(float 0.000000e+00, metadata !"fpexcept.strict") #0
+  %conv1 = tail call float @llvm.experimental.constrained.sitofp.f32.i32(i32 %conv, metadata !"round.tonearest", metadata !"fpexcept.strict") #0
+  %cmp3 = tail call i1 @llvm.experimental.constrained.fcmps.f32(float %conv1, float 0.000000e+00, metadata !"olt", metadata !"fpexcept.strict") #0
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare float @llvm.experimental.constrained.sitofp.f32.i32(i32, metadata, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i32 @llvm.experimental.constrained.fptosi.i32.f32(float, metadata) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i1 @llvm.experimental.constrained.fcmps.f32(float, float, metadata, metadata) #1
+
+attributes #0 = { strictfp }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }

--- a/tests/arm-tv/vectors/scvtf/SCVTFv1i64.aarch64.ll
+++ b/tests/arm-tv/vectors/scvtf/SCVTFv1i64.aarch64.ll
@@ -1,0 +1,20 @@
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i1 @llvm.experimental.constrained.fcmp.f64(double, double, metadata, metadata) #0
+
+; Function Attrs: strictfp
+define double @_ZN11xalanc_1_1013DoubleSupport7modulusEdd() #1 {
+entry:
+  %conv10 = tail call i64 @llvm.experimental.constrained.fptosi.i64.f64(double 0.000000e+00, metadata !"fpexcept.strict") #1
+  %conv11 = tail call double @llvm.experimental.constrained.sitofp.f64.i64(i64 %conv10, metadata !"round.tonearest", metadata !"fpexcept.strict") #1
+  %cmp12 = tail call i1 @llvm.experimental.constrained.fcmp.f64(double %conv11, double 0.000000e+00, metadata !"oeq", metadata !"fpexcept.strict") #1
+  ret double 0.000000e+00
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare i64 @llvm.experimental.constrained.fptosi.i64.f64(double, metadata) #0
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite)
+declare double @llvm.experimental.constrained.sitofp.f64.i64(i64, metadata, metadata) #0
+
+attributes #0 = { nocallback nofree nosync nounwind willreturn memory(inaccessiblemem: readwrite) }
+attributes #1 = { strictfp }


### PR DESCRIPTION
Added support for `FCVTZS (scalar, integer)`
Reimplemented `FCVT` and `FCVTZU (scalar, integer)` to explicitly convert to floating-point
Added tests for some unsupported instructions to be worked on next