### PR TITLE
Added support for `FMOV (vector, immediate)`

### DIFF
--- a/tests/arm-tv/vectors/fmov/FMOVv2f32_ns.aarch64.ll
+++ b/tests/arm-tv/vectors/fmov/FMOVv2f32_ns.aarch64.ll
@@ -1,0 +1,8 @@
+; Function Attrs: strictfp
+define i32 @nlaedit_add_transition_exec(ptr %0) #0 {
+entry:
+  store <2 x float> <float 1.000000e+00, float 1.000000e+00>, ptr %0, align 8
+  ret i32 0
+}
+
+attributes #0 = { strictfp }

--- a/tests/arm-tv/vectors/fmov/FMOVv2f64_ns.aarch64.ll
+++ b/tests/arm-tv/vectors/fmov/FMOVv2f64_ns.aarch64.ll
@@ -1,0 +1,4 @@
+; Function Attrs: nounwind ssp memory(none)
+define <2 x i64> @f() {
+  ret <2 x i64> <i64 -4628011567076605952, i64 -4628011567076605952>
+}

--- a/tests/arm-tv/vectors/fmov/FMOVv4f32_ns.aarch64.ll
+++ b/tests/arm-tv/vectors/fmov/FMOVv4f32_ns.aarch64.ll
@@ -1,0 +1,4 @@
+; Function Attrs: nounwind ssp memory(none)
+define <4 x i32> @f() {
+  ret <4 x i32> <i32 -1096286208, i32 -1096286208, i32 -1096286208, i32 -1096286208>
+}


### PR DESCRIPTION
Added support for `FMOV (vector, immediate)`
Not supporting half precision variants due to lack of tests