### PR TITLE
Bug fi

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -7479,6 +7479,7 @@ public:
       auto res = createFusedMultiplyAdd(a, b, c);
 
       updateOutputReg(res);
+      break;
     }
 
     case AArch64::FSQRTSr:


### PR DESCRIPTION
Bug fix - Missed a break in FMA instructions causing the `arm-tv/vectors/fnmul/FNMULSrr.aarch64.ll` and `arm-tv/vectors/fmsub/FMSUBSrrr.aarch64.ll` to fail