### PR TITLE
Added support for the `PRFM (immediate, literal, register)` and `PRFUM`
Added support for `HINT`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -1187,6 +1187,12 @@ class arm2llvm {
       AArch64::FRINTADr,
       AArch64::FRINTMDr,
       AArch64::FRINTPDr,
+      AArch64::PRFMl,
+      AArch64::PRFMroW,
+      AArch64::PRFMroX,
+      AArch64::PRFMui,
+      AArch64::PRFUMi,
+      AArch64::HINT,
   };
 
   const set<int> instrs_128 = {
@@ -4034,6 +4040,16 @@ public:
     auto i128 = getIntTy(128);
 
     switch (opcode) {
+
+    case AArch64::PRFMl:
+    case AArch64::PRFMroW:
+    case AArch64::PRFMroX:
+    case AArch64::PRFMui:
+    case AArch64::PRFUMi:
+    case AArch64::HINT: {
+      // NO-OPS
+      break;
+    }
 
     // we're abusing this opcode -- better hope we don't run across these for
     // real
@@ -7103,14 +7119,14 @@ public:
       }
 
       bool sExt = false;
-      switch(opcode) {
-        case AArch64::LDPSWpre:
-        case AArch64::LDPSWpost:
-          sExt = true;
-          break;
-        default:
-          sExt = false;
-          break;
+      switch (opcode) {
+      case AArch64::LDPSWpre:
+      case AArch64::LDPSWpost:
+        sExt = true;
+        break;
+      default:
+        sExt = false;
+        break;
       }
       unsigned size = pow(2, scale);
       auto &op0 = CurInst->getOperand(0);
@@ -7538,26 +7554,26 @@ public:
       auto md = MDString::get(Ctx, "fpexcept.strict");
       Value *converted;
       switch (opcode) {
-        case AArch64::FRINTASr:
-        case AArch64::FRINTADr: {
-                converted = createConstrainedRound(
-                readFromFPOperand(1, getRegSize(op1.getReg())), md);
-                break;
-                }
-        case AArch64::FRINTMSr:
-        case AArch64::FRINTMDr: {
-          converted = createConstrainedFloor(
-              readFromFPOperand(1, getRegSize(op1.getReg())), md);
-          break;
-        }
-        case AArch64::FRINTPSr:
-        case AArch64::FRINTPDr: {
-          converted = createConstrainedCeil(
-              readFromFPOperand(1, getRegSize(op1.getReg())), md);
-          break;
-        }
+      case AArch64::FRINTASr:
+      case AArch64::FRINTADr: {
+        converted = createConstrainedRound(
+            readFromFPOperand(1, getRegSize(op1.getReg())), md);
+        break;
+      }
+      case AArch64::FRINTMSr:
+      case AArch64::FRINTMDr: {
+        converted = createConstrainedFloor(
+            readFromFPOperand(1, getRegSize(op1.getReg())), md);
+        break;
+      }
+      case AArch64::FRINTPSr:
+      case AArch64::FRINTPDr: {
+        converted = createConstrainedCeil(
+            readFromFPOperand(1, getRegSize(op1.getReg())), md);
+        break;
+      }
       default:
-	assert(false);
+        assert(false);
       }
 
       updateOutputReg(converted);

--- a/tests/arm-tv/misc/hint.aarch64.ll
+++ b/tests/arm-tv/misc/hint.aarch64.ll
@@ -1,0 +1,10 @@
+define i32 @f(i32 %0) {
+  %2 = add nsw i32 %0, 1
+  ret i32 %2
+}
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 8, !"branch-target-enforcement", i32 1}
+!1 = !{i32 8, !"sign-return-address", i32 1}
+!2 = !{i32 8, !"sign-return-address-all", i32 0}

--- a/tests/arm-tv/misc/prefetch/PFRUMi.aarch64.ll
+++ b/tests/arm-tv/misc/prefetch/PFRUMi.aarch64.ll
@@ -1,0 +1,12 @@
+define void @f() {
+  %1 = alloca [100 x i8], align 1
+  %2 = getelementptr inbounds [100 x i8], ptr %1, i32 0, i32 50
+  %3 = getelementptr inbounds [100 x i8], ptr %1, i32 0, i32 -50
+  call void @llvm.prefetch.p0(ptr %1, i32 0, i32 3, i32 0)
+  call void @llvm.prefetch.p0(ptr %2, i32 0, i32 3, i32 0)
+  call void @llvm.prefetch.p0(ptr %3, i32 0, i32 3, i32 0)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
+declare void @llvm.prefetch.p0(ptr nocapture readonly, i32 immarg, i32 immarg, i32 immarg) #0

--- a/tests/arm-tv/misc/prefetch/PRFMui.aarch64.ll
+++ b/tests/arm-tv/misc/prefetch/PRFMui.aarch64.ll
@@ -1,0 +1,8 @@
+; Function Attrs: nounwind
+define void @f(ptr %0) {
+  call void @llvm.prefetch.p0(ptr %0, i32 0, i32 2, i32 1)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite, inaccessiblemem: readwrite)
+declare void @llvm.prefetch.p0(ptr nocapture readonly, i32 immarg, i32 immarg, i32 immarg) #1


### PR DESCRIPTION
Added support for the `PRFM (immediate, literal, register)` and `PRFUM`
Added support for `HINT`