### PR TITLE
Complete support for `SUB (vector)` by adding missing variant `SUBv1i64`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -765,6 +765,7 @@ class arm2llvm {
       AArch64::SSHLv1i64,
       AArch64::SSHLv4i16,
       AArch64::SSHLv2i32,
+      AArch64::SUBv1i64,
       AArch64::SUBv2i32,
       AArch64::SUBv4i16,
       AArch64::SUBv8i8,
@@ -3393,7 +3394,7 @@ class arm2llvm {
     auto i32 = getIntTy(32);
     auto i64 = getIntTy(64);
 
-    if (true) {
+    if (false) {
       /*
        * ABI stuff: on all return paths, check that callee-saved +
        * other registers have been reset to their previous
@@ -9156,6 +9157,7 @@ public:
     case AArch64::SSUBWv8i16_v4i32:
     case AArch64::SSUBWv2i32_v2i64:
     case AArch64::SSUBWv4i32_v2i64:
+    case AArch64::SUBv1i64:
     case AArch64::SUBv2i32:
     case AArch64::SUBv2i64:
     case AArch64::SUBv4i16:
@@ -9484,6 +9486,7 @@ public:
         }
         op = [&](Value *a, Value *b) { return createSub(a, b); };
         break;
+      case AArch64::SUBv1i64:
       case AArch64::SUBv2i32:
       case AArch64::SUBv2i64:
       case AArch64::SUBv4i16:
@@ -9554,6 +9557,7 @@ public:
       case AArch64::USHLv1i64:
       case AArch64::SSHLv1i64:
       case AArch64::ADDv1i64:
+      case AArch64::SUBv1i64:
         numElts = 1;
         eltSize = 64;
         break;

--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -3394,7 +3394,7 @@ class arm2llvm {
     auto i32 = getIntTy(32);
     auto i64 = getIntTy(64);
 
-    if (false) {
+    if (true) {
       /*
        * ABI stuff: on all return paths, check that callee-saved +
        * other registers have been reset to their previous

--- a/tests/arm-tv/vectors/sub/SUBv1i64.aarch64.ll
+++ b/tests/arm-tv/vectors/sub/SUBv1i64.aarch64.ll
@@ -1,0 +1,9 @@
+; Function Attrs: nounwind
+define i64 @f(<1 x i64> %0, <2 x i64> %1) {
+  %3 = extractelement <1 x i64> %0, i32 0
+  %4 = extractelement <2 x i64> %1, i32 0
+  %5 = extractelement <2 x i64> %1, i32 1
+  %6 = sub i64 %3, %4
+  %7 = sub i64 %6, %5
+  ret i64 %7
+}


### PR DESCRIPTION
Complete support for `SUB (vector)` by adding missing variant `SUBv1i64`