### PR TITLE
Added support for `PACIA`, `PACIB`, `AUTIA`, `AUTIB`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -1236,6 +1236,10 @@ class arm2llvm {
       AArch64::PRFMroX,
       AArch64::PRFMui,
       AArch64::PRFUMi,
+      AArch64::PACIASP,
+      AArch64::PACIBSP,
+      AArch64::AUTIASP,
+      AArch64::AUTIBSP,
       AArch64::HINT,
   };
 
@@ -4211,6 +4215,10 @@ public:
     case AArch64::PRFMroX:
     case AArch64::PRFMui:
     case AArch64::PRFUMi:
+    case AArch64::PACIASP:
+    case AArch64::PACIBSP:
+    case AArch64::AUTIASP:
+    case AArch64::AUTIBSP:
     case AArch64::HINT: {
       // NO-OPS
       break;

--- a/tests/arm-tv/misc/pointer-authentication/AUTIASP.aarch64.ll
+++ b/tests/arm-tv/misc/pointer-authentication/AUTIASP.aarch64.ll
@@ -1,0 +1,8 @@
+define i32 @f(i32 %0) {
+  ret i32 %0
+}
+
+!llvm.module.flags = !{!0, !1}
+
+!0 = !{i32 8, !"sign-return-address", i32 1}
+!1 = !{i32 8, !"sign-return-address-all", i32 1}

--- a/tests/arm-tv/misc/pointer-authentication/AUTIBSP.aarch64.ll
+++ b/tests/arm-tv/misc/pointer-authentication/AUTIBSP.aarch64.ll
@@ -1,0 +1,10 @@
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @f() {
+  ret i32 42
+}
+
+!llvm.module.flags = !{ !1, !2, !3}
+
+!1 = !{i32 8, !"sign-return-address", i32 1}
+!2 = !{i32 8, !"sign-return-address-all", i32 1}
+!3 = !{i32 8, !"sign-return-address-with-bkey", i32 1}

--- a/tests/arm-tv/misc/pointer-authentication/PACIASP.aarch64.ll
+++ b/tests/arm-tv/misc/pointer-authentication/PACIASP.aarch64.ll
@@ -1,0 +1,8 @@
+define i32 @f(i32 %0) {
+  ret i32 %0
+}
+
+!llvm.module.flags = !{!0, !1}
+
+!0 = !{i32 8, !"sign-return-address", i32 1}
+!1 = !{i32 8, !"sign-return-address-all", i32 1}

--- a/tests/arm-tv/misc/pointer-authentication/PACIBSP.aarch64.ll
+++ b/tests/arm-tv/misc/pointer-authentication/PACIBSP.aarch64.ll
@@ -1,0 +1,10 @@
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @f() {
+  ret i32 42
+}
+
+!llvm.module.flags = !{ !1, !2, !3}
+
+!1 = !{i32 8, !"sign-return-address", i32 1}
+!2 = !{i32 8, !"sign-return-address-all", i32 1}
+!3 = !{i32 8, !"sign-return-address-with-bkey", i32 1}


### PR DESCRIPTION
Added support for some pointer authentication instructions. They are just NO-OPS: `PACIA`, `PACIB`, `AUTIA`, `AUTIB`