### PR TITLE
Bug Fix - `SMULL`, `UMULL`

### DIFF
--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -11251,59 +11251,65 @@ public:
     case AArch64::SMULLv8i16_indexed:
     case AArch64::SMULLv4i16_indexed:
     case AArch64::SMULLv2i32_indexed: {
-      int eltSize, numElts;
+      int eltSize, numElts1, numElts2;
       if (opcode == AArch64::SMULLv8i16_indexed ||
           opcode == AArch64::UMULLv8i16_indexed) {
-        numElts = 8;
+        numElts1 = 8;
+        numElts2 = 8;
         eltSize = 16;
       } else if (opcode == AArch64::SMULLv4i32_indexed ||
                  opcode == AArch64::UMULLv4i32_indexed) {
-        numElts = 4;
+        numElts1 = 4;
+        numElts2 = 4;
         eltSize = 32;
       } else if (opcode == AArch64::SMULLv2i32_indexed ||
                  opcode == AArch64::UMULLv2i32_indexed) {
-        numElts = 2;
+        numElts1 = 2;
+        numElts2 = 4;
         eltSize = 32;
       } else if (opcode == AArch64::SMULLv4i16_indexed ||
                  opcode == AArch64::UMULLv4i16_indexed) {
-        numElts = 4;
+        numElts1 = 4;
+        numElts2 = 8;
         eltSize = 16;
       } else {
         assert(false);
       }
-      auto vTy = getVecTy(eltSize, numElts);
-      auto vBigTy = getVecTy(2 * eltSize, numElts);
+      auto vTy1 = getVecTy(eltSize, numElts1);
+      auto vTy2 = getVecTy(eltSize, numElts2);
+      auto vBigTy1 = getVecTy(2 * eltSize, numElts1);
+      auto vBigTy2 = getVecTy(2 * eltSize, numElts2);
       Value *a, *b;
       switch (opcode) {
       case AArch64::UMULLv4i16_indexed:
       case AArch64::UMULLv2i32_indexed:
       case AArch64::UMULLv8i16_indexed:
       case AArch64::UMULLv4i32_indexed:
-        a = createZExt(createBitCast(readFromOperand(1), vTy), vBigTy);
-        b = createZExt(createBitCast(readFromOperand(2), vTy), vBigTy);
+        a = createZExt(createBitCast(readFromOperand(1), vTy1), vBigTy1);
+        b = createZExt(createBitCast(readFromOperand(2, 128), vTy2), vBigTy2);
         break;
       case AArch64::SMULLv4i32_indexed:
       case AArch64::SMULLv8i16_indexed:
       case AArch64::SMULLv4i16_indexed:
       case AArch64::SMULLv2i32_indexed:
-        a = createSExt(createBitCast(readFromOperand(1), vTy), vBigTy);
-        b = createSExt(createBitCast(readFromOperand(2), vTy), vBigTy);
+        a = createSExt(createBitCast(readFromOperand(1), vTy1), vBigTy1);
+        b = createSExt(createBitCast(readFromOperand(2, 128), vTy2), vBigTy2);
         break;
       default:
         assert(false);
       }
       auto idx = getImm(3);
-      Value *res = getUndefVec(numElts, 2 * eltSize);
+      Value *res = getUndefVec(numElts1, 2 * eltSize);
       // offset is nonzero when we're dealing with SMULL2/UMULL2
       int offset = (opcode == AArch64::SMULLv4i32_indexed ||
                     opcode == AArch64::SMULLv8i16_indexed ||
                     opcode == AArch64::UMULLv4i32_indexed ||
                     opcode == AArch64::UMULLv8i16_indexed)
-                       ? (numElts / 2)
+                       ? (numElts1 / 2)
                        : 0;
-      for (int i = 0; i < numElts; ++i) {
+      auto e2 = createExtractElement(b, idx);
+      for (int i = 0; i < numElts1; ++i) {
         auto e1 = createExtractElement(a, i + offset);
-        auto e2 = createExtractElement(b, idx);
         res = createInsertElement(res, createMul(e1, e2), i);
       }
       updateOutputReg(res);

--- a/tests/arm-tv/vectors/smull/SMULLv4i16_indexed.aarch64.ll
+++ b/tests/arm-tv/vectors/smull/SMULLv4i16_indexed.aarch64.ll
@@ -1,0 +1,8 @@
+define <4 x i16> @f(<8 x i16> %0, <4 x i16> %1) {
+  %3 = shufflevector <8 x i16> %0, <8 x i16> zeroinitializer, <4 x i32> <i32 5, i32 5, i32 5, i32 5>
+  %4 = zext <4 x i16> %3 to <4 x i32>
+  %5 = zext <4 x i16> %1 to <4 x i32>
+  %new0 = mul <4 x i32> %4, %5
+  %last = trunc <4 x i32> %new0 to <4 x i16>
+  ret <4 x i16> %last
+}


### PR DESCRIPTION
Bug Fix - `SMULL`, `UMULL`
Vector being indexed into was being truncated due to the instruction size sets and als usage of incorrect vector type was causing out of bounds access on certain instances.