### PR TITLE
aslp: add basic varnish cache

### DIFF
--- a/aslp-server.sh
+++ b/aslp-server.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+cd "$(dirname "$0")"
+if ! [[ -d build ]]; then echo "$0 should be run after build.sh" >&2; exit 1; fi
+
+VARNISH_DIR=$(mktemp -d -t aslp-server-varnish.XXXX)
+echo "VARNISH_DIR=$VARNISH_DIR"
+mkdir -p "$VARNISH_DIR"
+
+trap "trap - SIGTERM && rm -rfv $VARNISH_DIR && kill -- -$$" SIGINT SIGTERM EXIT
+
+cd build
+
+# write varnish cache configuration file
+cat <<EOF >$VARNISH_DIR/default.vcl
+vcl 4.0;
+
+backend default {
+  .host = "127.0.0.1";
+  .port = "8100";
+}
+
+sub vcl_recv {
+  # aslp bridge checks / to see if the server is up, make this very fast.
+  if (req.url == "/") {
+    return(synth(200));
+  }
+  if (req.url == "/favicon.ico") {
+    return(synth(404));
+  }
+}
+
+sub vcl_backend_response {
+  set beresp.ttl = 24h;
+}
+EOF
+
+aslp/bin/aslp-server --port 8100 &
+pid=$!
+sleep 1
+if ! kill -0 "$pid"; then
+  echo 'aslp-server exited suspiciously soon... quitting in case of initialisation error.' >&2
+  exit 1
+fi
+
+echo
+./varnish/bin/varnishd -F -a localhost:8000 -n $VARNISH_DIR -f $VARNISH_DIR/default.vcl -s memory=malloc,4G
+
+
+: <<'END_COMMENT'
+admin console:
+build/varnish/bin/varnishadm -n $VARNISH_DIR
+
+logs:
+build/varnish/bin/varnishlog -n $VARNISH_DIR -b
+
+table of statistics:
+build/varnish/bin/varnishstat -n $VARNISH_DIR
+
+list of fetched URLS:
+build/varnish/bin/varnishtop -I ReqURL:opcode -n $VARNISH_DIR
+END_COMMENT

--- a/backend_tv/aslp/README.md
+++ b/backend_tv/aslp/README.md
@@ -30,8 +30,10 @@ These instructions will install all of the required dependencies and build the b
    ```
 4. Start aslp-server and leave running:
    ```bash
-   ./build/aslp/bin/aslp-server  # or otherwise, if already installed
+   ./aslp-server.sh
    ```
+   This will run aslp-server behind a Varnish cache server, caching the ASLp semantics in memory.
+   See the script for more details.
 5. Use backend-tv, for example:
    ```bash
    ./build/backend-tv ./tests/arm-tv/cmp/sgt.aarch64.ll
@@ -43,14 +45,14 @@ This might be useful to use local versions of particular dependencies.
 cmake -B build -DBUILD_TV=1 \
   -DCMAKE_PREFIX_PATH=./antlr-dev/.';'~/progs/llvm-regehr/llvm/build/ \
   -DANTLR4_JAR_LOCATION=./antlr-4.13.0-complete.jar \
-  -DFETCHCONTENT_SOURCE_DIR_ASLP-CPP=~/progs/aslp 
+  -DFETCHCONTENT_SOURCE_DIR_ASLP-CPP=~/progs/aslp
 ```
 
 <!--
 You will also need the *aslp-server* which provides the Aslp semantics over HTTP.
 The suggested way to get this is using the Nix package manager. Once Nix is installed, use
 ```bash
-nix --extra-experimental-features nix-command --extra-experimental-features flakes shell github:katrinafyi/pac-nix#aslp --command aslp-server 
+nix --extra-experimental-features nix-command --extra-experimental-features flakes shell github:katrinafyi/pac-nix#aslp --command aslp-server
 ```
 This should build and launch aslp-server from the [pac-nix](https://github.com/katrinafyi/pac-nix) packages.
 Otherwise, you can compile with Dune from the [aslp](https://github.com/UQ-PAC/aslp) repository then run `dune exec aslp-server`.
@@ -157,7 +159,7 @@ The classic lifter, operating in LLVM, takes advantage of LLVM's vector function
 This makes the semantics cleaner and easier to reason about.
 Aslp, however, treats vector registers no different from ordinary scalar registers and performs vector operations by
 bitwise operations on the full 128-bit width.
-This is obviously much worse for Alive to reason with and, as in the calls/vec test, affects how poison values spread across vector elements. 
+This is obviously much worse for Alive to reason with and, as in the calls/vec test, affects how poison values spread across vector elements.
 It is conceivable that an LLVM optimisation pass could detect and replace these operations with their vector counterparts,
 but it does not do so right now.
 

--- a/build.sh
+++ b/build.sh
@@ -15,11 +15,20 @@ if ! [[ -d antlr-dev ]]; then
   nix build 'nixpkgs/655a58a72a6601292512670343087c2d75d859c1#antlr.runtime.cpp^dev' -o antlr
 fi
 if ! [[ -d llvm-dev ]]; then
-  nix build 'github:katrinafyi/pac-nix/llvm-for-alive2#llvm-custom-git.libllvm^dev' -o llvm
+  nix build 'github:katrinafyi/pac-nix/97d071335a0044b5153bca7aed2513b588fffcaf#llvm-custom-git.libllvm^dev' -o llvm
 fi
-if ! ( [[ -d aslp ]] || command -v aslp-server &>/dev/null ); then
+
+if [[ -d aslp ]]; then :
+elif command -v aslp-server &>/dev/null; then
+  mkdir -p aslp/bin; ln -s $(which aslp-server) ./aslp/bin
+else
   nix build 'github:katrinafyi/pac-nix#aslp' -o aslp
 fi
+
+if ! [[ -d varnish ]]; then
+  nix build 'nixpkgs/655a58a72a6601292512670343087c2d75d859c1#varnish' -o varnish
+fi
+
 cd ..
 
 if command -v clang++ &>/dev/null && [[ -z "$CXX" ]]; then


### PR DESCRIPTION
This is a simple in-memory cache in front of the aslp-server. It should speed things up considerably, assuming some opcodes are much more frequent than others.