### PR TITLE
aslp: update references to aslp-server and aslp-cpp

### DIFF
--- a/backend_tv/aslp/CMakeLists.txt
+++ b/backend_tv/aslp/CMakeLists.txt
@@ -27,10 +27,10 @@ message(STATUS "AArch64GenInstrInfo.inc: ${AARCH64_INSTR_INC}")
 
 include(FetchContent)
 FetchContent_Declare(aslp-cpp
-  URL https://github.com/UQ-PAC/aslp/archive/partial_eval.zip
+  URL https://github.com/UQ-PAC/aslp-rpc/archive/main.zip
   # GIT_REPOSITORY https://github.com/UQ-PAC/aslp.git
   # GIT_TAG        clientserver
-  SOURCE_SUBDIR  aslp-cpp
+  SOURCE_SUBDIR aslp-client-http-cpp
   DOWNLOAD_EXTRACT_TIMESTAMP false
   FIND_PACKAGE_ARGS
 )

--- a/backend_tv/aslp/aslp_bridge.cpp
+++ b/backend_tv/aslp/aslp_bridge.cpp
@@ -51,7 +51,7 @@ aslp_connection make_conn() {
   if (config.vectors && !extra_params.contains("flags")) {
     extra_params.insert({"flags", "+dis:vectors"});
   }
-  auto conn = aslp_connection{config.server_addr, static_cast<int>(config.server_port), extra_params};
+  auto conn = aslp_connection{config.server_addr, static_cast<int>(config.server_port), extra_params, true};
   if (config.enable)
     conn.wait_active();
   return conn;

--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ if [[ -d aslp ]]; then :
 elif command -v aslp-server &>/dev/null; then
   mkdir -p aslp/bin; ln -s $(which aslp-server) ./aslp/bin
 else
-  nix build 'github:katrinafyi/pac-nix#aslp' -o aslp
+  nix build 'github:katrinafyi/pac-nix#aslp-server' -o aslp
 fi
 
 if ! [[ -d varnish ]]; then


### PR DESCRIPTION
we've moved around our repositories to separate the client/server code
from the main aslp repository.

possible breaking! this adds a new parameter to the aslp_connection
constructor. this will require a newer version of aslp-cpp.

if you are building with ./build.sh, deleting the build directory should
automatically fetch the correct version.