### PR TITLE
update Nix llvm version in build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ fi
 if [[ -n "$LLVM_ROOT" ]]; then
   ln -s "$LLVM_ROOT" ./llvm-dev
 elif ! [[ -d llvm-dev ]]; then
-  nix build 'github:katrinafyi/pac-nix/llvm-update-2025-01#llvm-custom-git.libllvm^dev' -o llvm
+  nix build 'github:katrinafyi/pac-nix/ac6bd13f242a782e1c69da6cdab2fe1322871bd3#llvm-custom-git.libllvm^dev' -o llvm
 fi
 
 if [[ -d aslp ]]; then :


### PR DESCRIPTION
this updates LLVM to a more recent version from May and enables risc-v in the build.

with the significant caveat that using LLVM from Nix crashes at runtime ("pass initialisation error")