### PR TITLE
Avoid pointer round trips

### DIFF
--- a/tests/arm-tv/ptrroundtrips/round-trip-test-0.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-0.aarch64.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -run-replace-ptrtoint
+; should collapse into gep
+define ptr @f(ptr %p, i64 %idx) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %i1, %idx
+    %r = inttoptr i64 %i2 to ptr
+    ret ptr %r
+}
+
+; CHECK: gep ptr %#0

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-0.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-0.aarch64.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -run-replace-ptrtoint
+; TEST-ARGS: -test-replace-ptrtoint
 ; should collapse into gep
 define ptr @f(ptr %p, i64 %idx) {
     %i1 = ptrtoint ptr %p to i64
@@ -7,4 +7,6 @@ define ptr @f(ptr %p, i64 %idx) {
     ret ptr %r
 }
 
-; CHECK: gep ptr %#0
+; CHECK: getelementptr
+; CHECK-NOT: inttoptr
+; CHECK-NOT: ptrtoint

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
@@ -1,5 +1,5 @@
-; TEST-ARGS: -run-replace-ptrtoint
-; should optimize 2 geps ; currently gets scrambled
+; TEST-ARGS: -test-replace-ptrtoint
+
 define ptr @g(ptr noundef %p, i64 noundef %idx1, i64 noundef %idx2) {
     %i1 = ptrtoint ptr %p to i64
     %i2 = add i64 %i1, %idx1
@@ -13,3 +13,5 @@ define ptr @g(ptr noundef %p, i64 noundef %idx1, i64 noundef %idx2) {
     %max = select i1 %cmp, ptr %p1, ptr %p2 ; cmp ? p1 : p2
     ret ptr %max
 }
+
+; CHECK: getelementptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
@@ -1,0 +1,15 @@
+; TEST-ARGS: -run-replace-ptrtoint
+; should optimize 2 geps ; currently gets scrambled
+define ptr @g(ptr noundef %p, i64 noundef %idx1, i64 noundef %idx2) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %i1, %idx1
+    %p1 = inttoptr i64 %i2 to ptr
+
+    %i3 = ptrtoint ptr %p to i64
+    %i4 = add i64 %i3, %idx2
+    %p2 = inttoptr i64 %i4 to ptr
+
+    %cmp = icmp sgt ptr %p1, %p2            ; set if p1 > p2
+    %max = select i1 %cmp, ptr %p1, ptr %p2 ; cmp ? p1 : p2
+    ret ptr %max
+}

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
@@ -16,3 +16,5 @@ define ptr @g(ptr noundef %p, i64 noundef %idx1, i64 noundef %idx2) {
 
 ; CHECK: getelementptr
 ; CHECK: getelementptr
+; CHECK-NOT: inttoptr
+; CHECK-NOT: ptrtoint

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-1.aarch64.ll
@@ -15,3 +15,4 @@ define ptr @g(ptr noundef %p, i64 noundef %idx1, i64 noundef %idx2) {
 }
 
 ; CHECK: getelementptr
+; CHECK: getelementptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
@@ -2,7 +2,7 @@
 ; should collapse into gep
 define ptr @h(ptr %p, i64 %idx) {
     %i1 = ptrtoint ptr %p to i64
-    %i2 = add i64 %idx, %i1
+    %i2 = add i64 %idx, %i1     ; ptr is left operand here
     %r = inttoptr i64 %i2 to ptr
     ret ptr %r
 }

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -run-replace-ptrtoint
+; TEST-ARGS: -test-replace-ptrtoint
 ; should collapse into gep
 define ptr @h(ptr %p, i64 %idx) {
     %i1 = ptrtoint ptr %p to i64
@@ -7,4 +7,6 @@ define ptr @h(ptr %p, i64 %idx) {
     ret ptr %r
 }
 
-; CHECK: gep ptr %#0
+; CHECK: getelementptr
+; CHECK-NOT: inttoptr
+; CHECK-NOT: ptrtoint

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-2.aarch64.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -run-replace-ptrtoint
+; should collapse into gep
+define ptr @h(ptr %p, i64 %idx) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %idx, %i1
+    %r = inttoptr i64 %i2 to ptr
+    ret ptr %r
+}
+
+; CHECK: gep ptr %#0

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-3.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-3.aarch64.ll
@@ -1,0 +1,13 @@
+; TEST-ARGS: -run-replace-ptrtoint
+; should not collapse gep
+define ptr @b(ptr %p, i64 %idx, ptr nocapture noundef %x) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %i1, %idx      ; can't destroy, has a use
+    %r = inttoptr i64 %i2 to ptr
+
+    store i64 %i2, ptr %x, align 8
+
+    ret ptr %r
+}
+
+; CHECK-NOT: gep ptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-3.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-3.aarch64.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -run-replace-ptrtoint
+; TEST-ARGS: -test-replace-ptrtoint
 ; should not collapse gep
 define ptr @b(ptr %p, i64 %idx, ptr nocapture noundef %x) {
     %i1 = ptrtoint ptr %p to i64
@@ -10,4 +10,4 @@ define ptr @b(ptr %p, i64 %idx, ptr nocapture noundef %x) {
     ret ptr %r
 }
 
-; CHECK-NOT: gep ptr
+; CHECK-NOT: getelementptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-4.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-4.aarch64.ll
@@ -1,4 +1,4 @@
-; TEST-ARGS: -run-replace-ptrtoint
+; TEST-ARGS: -test-replace-ptrtoint
 ; should not collapse gep
 define ptr @c(ptr %p, i64 %idx, ptr nocapture noundef %x) {
     %i1 = ptrtoint ptr %p to i64 ; can't destroy, has a use
@@ -10,4 +10,4 @@ define ptr @c(ptr %p, i64 %idx, ptr nocapture noundef %x) {
     ret ptr %r
 }
 
-; CHECK-NOT: gep ptr
+; CHECK-NOT: getelementptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-4.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-4.aarch64.ll
@@ -1,0 +1,13 @@
+; TEST-ARGS: -run-replace-ptrtoint
+; should not collapse gep
+define ptr @c(ptr %p, i64 %idx, ptr nocapture noundef %x) {
+    %i1 = ptrtoint ptr %p to i64 ; can't destroy, has a use
+    %i2 = add i64 %i1, %idx
+    %r = inttoptr i64 %i2 to ptr
+
+    store i64 %i1, ptr %x, align 8
+
+    ret ptr %r
+}
+
+; CHECK-NOT: gep ptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-5.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-5.aarch64.ll
@@ -1,0 +1,10 @@
+; TEST-ARGS: -test-replace-ptrtoint
+; should collapse into gep
+define ptr @f(ptr %p, i64 %idx) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %i1, %idx
+    %r = inttoptr i64 %i2 to ptr
+    ret ptr %r
+}
+
+; CHECK: getelementptr

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-5.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-5.aarch64.ll
@@ -8,3 +8,5 @@ define ptr @f(ptr %p, i64 %idx) {
 }
 
 ; CHECK: getelementptr
+; CHECK-NOT: inttoptr
+; CHECK-NOT: ptrtoint

--- a/tests/arm-tv/ptrroundtrips/round-trip-test-6.aarch64.ll
+++ b/tests/arm-tv/ptrroundtrips/round-trip-test-6.aarch64.ll
@@ -1,0 +1,13 @@
+; TEST-ARGS: -test-replace-ptrtoint
+; should not collapse gep
+define ptr @b(ptr %p, i64 %idx, ptr nocapture noundef %x) {
+    %i1 = ptrtoint ptr %p to i64
+    %i2 = add i64 %i1, %idx      ; can't destroy, has a use
+    %r = inttoptr i64 %i2 to ptr
+
+    store i64 %i2, ptr %x, align 8
+
+    ret ptr %r
+}
+
+; CHECK-NOT: getelementptr

--- a/tools/backend-tv.cpp
+++ b/tools/backend-tv.cpp
@@ -10,14 +10,12 @@
 #include "tools/transform.h"
 #include "util/version.h"
 
-#include "Target/AArch64/AArch64Subtarget.h"
 #include "AArch64TargetMachine.h"
-#include "llvm/IR/DataLayout.h"
-#include "llvm/MC/TargetRegistry.h"
-#include "llvm/Support/TargetSelect.h"
+#include "Target/AArch64/AArch64Subtarget.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
 #include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/IR/DataLayout.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/InstIterator.h"
@@ -27,13 +25,15 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IRReader/IRReader.h"
 #include "llvm/InitializePasses.h"
+#include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
-#include "llvm/Support/raw_ostream.h"
+#include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_os_ostream.h"
+#include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/IPO/GlobalDCE.h"
 #include "llvm/Transforms/IPO/Internalize.h"
@@ -119,8 +119,8 @@ llvm::cl::opt<bool> run_replace_ptrtoint(
 
 llvm::cl::opt<bool> test_replace_ptrtoint(
     "test-replace-ptrtoint",
-    llvm::cl::desc(
-        "Test run-replace-ptrtoint flag by running the pass on source (default=false)"),
+    llvm::cl::desc("Test run-replace-ptrtoint flag by running the pass on "
+                   "source (default=false)"),
     llvm::cl::init(false), llvm::cl::cat(alive_cmdargs));
 
 llvm::cl::opt<string> opt_asm_input(
@@ -272,9 +272,8 @@ void doit(llvm::Module *srcModule, llvm::Function *srcFn, Verifier &verifier,
   std::unordered_map<unsigned, llvm::Instruction *> lineMap;
   if (opt_asm_input == "") {
     lifter::addDebugInfo(srcFn, lineMap);
-    AsmBuffer = lifter::generateAsm(*srcModule, Targ, DefaultTT,
-	 DefaultCPU,
-	 DefaultFeatures);
+    AsmBuffer = lifter::generateAsm(*srcModule, Targ, DefaultTT, DefaultCPU,
+                                    DefaultFeatures);
   } else {
     AsmBuffer = ExitOnErr(
         llvm::errorOrToExpected(llvm::MemoryBuffer::getFile(opt_asm_input)));
@@ -301,9 +300,9 @@ void doit(llvm::Module *srcModule, llvm::Function *srcFn, Verifier &verifier,
   if (opt_asm_only)
     exit(0);
 
-  auto [F1, F2] = lifter::liftFunc(srcFn, std::move(AsmBuffer), lineMap, opt_optimize_tgt, out, Targ, DefaultTT,
-				   	  DefaultCPU,
-	DefaultFeatures);
+  auto [F1, F2] =
+      lifter::liftFunc(srcFn, std::move(AsmBuffer), lineMap, opt_optimize_tgt,
+                       out, Targ, DefaultTT, DefaultCPU, DefaultFeatures);
 
   auto lifted = lifter::moduleToString(F2->getParent());
   if (save_lifted_ir) {
@@ -381,8 +380,7 @@ version )EOF";
   // FIXME: we should avoid hard-coding these
   if (opt_backend == "aarch64") {
     DefaultTT = llvm::Triple("aarch64-unknown-linux-gnu");
-    DefaultDL =
-        "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32";
+    DefaultDL = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32";
     DefaultCPU = "generic";
     DefaultFeatures = "";
     LLVMInitializeAArch64TargetInfo();
@@ -406,7 +404,7 @@ version )EOF";
     *out << "ERROR: Only aarch64 or riscv64 are supported\n";
     exit(-1);
   }
-  
+
   srcModule.get()->setTargetTriple(DefaultTT);
   srcModule.get()->setDataLayout(DefaultDL);
 

--- a/tools/backend-tv.cpp
+++ b/tools/backend-tv.cpp
@@ -219,7 +219,6 @@ void doit(llvm::Module *srcModule, llvm::Function *srcFn, Verifier &verifier,
 
   if (test_replace_ptrtoint) {
     llvm::raw_os_ostream streamWrapper(*out);
-    srcFn->print(streamWrapper);
     tryReplacePtrtoInt(srcFn);
     srcFn->print(streamWrapper);
     streamWrapper.flush();

--- a/tools/backend-tv.cpp
+++ b/tools/backend-tv.cpp
@@ -10,7 +10,6 @@
 #include "tools/transform.h"
 #include "util/version.h"
 
-#include "AArch64TargetMachine.h"
 #include "Target/AArch64/AArch64Subtarget.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/Analysis/TargetLibraryInfo.h"
@@ -24,10 +23,8 @@
 #include "llvm/IR/Metadata.h"
 #include "llvm/IR/Module.h"
 #include "llvm/IRReader/IRReader.h"
-#include "llvm/InitializePasses.h"
 #include "llvm/MC/TargetRegistry.h"
 #include "llvm/Passes/PassBuilder.h"
-#include "llvm/Support/FileSystem.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/Signals.h"
 #include "llvm/Support/SourceMgr.h"
@@ -41,7 +38,6 @@
 
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <utility>
 
 using namespace tools;


### PR DESCRIPTION
Replace instances of `ptrtoint`->`add`->`inttoptr` with a single `getelementptr`. Can prevent timeouts with alive.