### PR TITLE
Add support for fp load/store/conversion

### DIFF
--- a/tests/riscv-tv/extensions/f/fcvt_d_l.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_d_l.riscv.ll
@@ -1,0 +1,6 @@
+define void @fcvt_d_l(i64 noundef %a, ptr noundef %p) {
+entry:
+  %conv = sitofp i64 %a to double
+  store double %conv, ptr %p, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_d_s.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_d_s.riscv.ll
@@ -1,0 +1,7 @@
+define void @fcvt_d_s(ptr noundef %p1, ptr noundef %p2) {
+entry:
+  %fp = load float, ptr %p1, align 4
+  %conv = fpext float %fp to double
+  store double %conv, ptr %p2, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_d_w.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_d_w.riscv.ll
@@ -1,0 +1,6 @@
+define void @fcvt_d_w(i32 noundef signext %a, ptr noundef %p) {
+entry:
+  %conv = sitofp i32 %a to double
+  store double %conv, ptr %p, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_d_wu.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_d_wu.riscv.ll
@@ -1,0 +1,6 @@
+define void @fcvt_d_wu(i32 noundef signext %a, ptr noundef %p) {
+entry:
+  %conv = uitofp i32 %a to double
+  store double %conv, ptr %p, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_lu_s.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_lu_s.riscv.ll
@@ -1,0 +1,6 @@
+define i64 @fcvt_lu_s(ptr noundef %p) {
+entry:
+  %fp = load float, ptr %p, align 4
+  %cvt = fptoui float %fp to i64
+  ret i64 %cvt
+}

--- a/tests/riscv-tv/extensions/f/fcvt_s_d.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_s_d.riscv.ll
@@ -1,0 +1,7 @@
+define void @fcvt_s_d(i8 noundef signext %a, ptr noundef %p2) {
+entry:
+  %fp = sitofp i8 %a to double
+  %conv = fptrunc double %fp to float
+  store float %conv, ptr %p2, align 4
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_s_l.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_s_l.riscv.ll
@@ -1,0 +1,6 @@
+define void @fcvt_s_l(i64 noundef %a, ptr noundef %p) {
+entry:
+  %conv = sitofp i64 %a to float
+  store float %conv, ptr %p, align 4
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_s_lu.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_s_lu.riscv.ll
@@ -1,0 +1,6 @@
+define void @fcvt_s_lu(i64 noundef %a, ptr noundef %p) {
+entry:
+  %conv = uitofp i64 %a to float
+  store float %conv, ptr %p, align 4
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fcvt_w_s.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fcvt_w_s.riscv.ll
@@ -1,0 +1,6 @@
+define signext i32 @fcvt_w_s(ptr noundef %p) {
+entry:
+  %fp = load float, ptr %p, align 4
+  %cvt = fptosi float %fp to i32
+  ret i32 %cvt
+}

--- a/tests/riscv-tv/extensions/f/fld.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fld.riscv.ll
@@ -1,0 +1,6 @@
+define i32 @fld(ptr noundef %a) {
+entry:
+  %fp = load double, ptr %a, align 8
+  %conv = fptosi double %fp to i32
+  ret i32 %conv
+}

--- a/tests/riscv-tv/extensions/f/flw.riscv.ll
+++ b/tests/riscv-tv/extensions/f/flw.riscv.ll
@@ -1,0 +1,6 @@
+define signext i32 @flw(ptr noundef %a) {
+entry:
+  %fp = load float, ptr %a, align 4
+  %conv = fptosi float %fp to i32
+  ret i32 %conv
+}

--- a/tests/riscv-tv/extensions/f/fmv_d_x.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmv_d_x.riscv.ll
@@ -1,0 +1,7 @@
+define void @fmv_d_x(i64 noundef %a, ptr noundef %p) {
+entry:
+  %cvt = bitcast i64 %a to double
+  %add = fadd double %cvt, 0.0
+  store double %add, ptr %p, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fmv_w_x.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmv_w_x.riscv.ll
@@ -1,0 +1,7 @@
+define void @fmv_w_x(i32 noundef signext %a, ptr noundef %p) {
+entry:
+  %cvt = bitcast i32 %a to float
+  %add = fadd float %cvt, 0.0
+  store float %add, ptr %p, align 4
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fmv_x_w.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmv_x_w.riscv.ll
@@ -1,0 +1,7 @@
+define signext i32 @fmv_x_w(ptr noundef %p) {
+entry:
+  %fp = load float, ptr %p, align 4
+  %add = fadd float %fp, 0.0
+  %cvt = bitcast float %add to i32
+  ret i32 %cvt
+}

--- a/tests/riscv-tv/extensions/f/fsd.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fsd.riscv.ll
@@ -1,0 +1,7 @@
+define void @fsd(ptr noundef %p) {
+entry:
+  %gep = getelementptr inbounds i8, ptr %p, i64 8
+  %fp = load double, ptr %gep, align 8
+  store double %fp, ptr %p, align 8
+  ret void
+}

--- a/tests/riscv-tv/extensions/f/fsw.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fsw.riscv.ll
@@ -1,0 +1,6 @@
+define void @fsw(i32 noundef signext %a, ptr noundef %p) {
+entry:
+  %conv = sitofp i32 %a to float
+  store float %conv, ptr %p, align 4
+  ret void
+}


### PR DESCRIPTION
Question: For narrowing conversion instructions, can we ignore the exception flags?
