### PR TITLE
Tentative support for FMIN.* and FMAX.* in RISCV-TV

### DIFF
--- a/backend_tv/aslp/interface.h
+++ b/backend_tv/aslp/interface.h
@@ -86,6 +86,10 @@ public:
 
   virtual expr_t createUMax(expr_t a, expr_t b) = 0;
 
+  virtual expr_t createMinimumNum(expr_t a, expr_t b) = 0;
+
+  virtual expr_t createMaximumNum(expr_t a, expr_t b) = 0;
+
   virtual expr_t createFNeg(expr_t v) = 0;
 
   virtual expr_t createFAbs(expr_t v) = 0;

--- a/backend_tv/mc2llvm.h
+++ b/backend_tv/mc2llvm.h
@@ -385,6 +385,18 @@ public:
     return llvm::CallInst::Create(decl, {a, b}, nextName(), LLVMBB);
   }
 
+  llvm::Value *createMinimumNum(llvm::Value *a, llvm::Value *b) override {
+    auto decl = llvm::Intrinsic::getOrInsertDeclaration(
+        LiftedModule, llvm::Intrinsic::minnum, a->getType());
+    return llvm::CallInst::Create(decl, {a, b}, nextName(), LLVMBB);
+  }
+
+  llvm::Value *createMaximumNum(llvm::Value *a, llvm::Value *b) override {
+    auto decl = llvm::Intrinsic::getOrInsertDeclaration(
+        LiftedModule, llvm::Intrinsic::maxnum, a->getType());
+    return llvm::CallInst::Create(decl, {a, b}, nextName(), LLVMBB);
+  }
+
   llvm::Value *createFNeg(llvm::Value *v) override {
     return llvm::UnaryOperator::CreateFNeg(v, nextName(), LLVMBB);
   }

--- a/backend_tv/riscv2llvm_insns.cpp
+++ b/backend_tv/riscv2llvm_insns.cpp
@@ -1047,6 +1047,8 @@ void riscv2llvm::lift(MCInst &I) {
     HANDLE_FP_BINARY_OP(FADD, FAdd);
     HANDLE_FP_BINARY_OP(FSUB, FSub);
     HANDLE_FP_BINARY_OP(FMUL, FMul);
+    HANDLE_FP_BINARY_OP(FMIN, MinimumNum);
+    HANDLE_FP_BINARY_OP(FMAX, MaximumNum);
 
 #undef HANDLE_FP_BINARY_OP
 

--- a/tests/riscv-tv/extensions/f/fmin_d.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmin_d.riscv.ll
@@ -1,0 +1,6 @@
+define dso_local noundef double @mind(double noundef %x, double noundef %y, double noundef %z) local_unnamed_addr #0 {
+entry:
+  %1 = call double @llvm.minnum.f64(double %x, double %y)
+  %2 = call double @llvm.minnum.f64(double %z, double %1)
+  ret double %2
+}

--- a/tests/riscv-tv/extensions/f/fmin_h.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmin_h.riscv.ll
@@ -1,0 +1,6 @@
+define dso_local noundef half @mins(half noundef %x, half noundef %y, half noundef %z) local_unnamed_addr #0 {
+entry:
+  %1 = call half @llvm.minnum.f16(half %x, half %y)
+  %2 = call half @llvm.minnum.f16(half %z, half %1)
+  ret half %2
+}

--- a/tests/riscv-tv/extensions/f/fmin_s.riscv.ll
+++ b/tests/riscv-tv/extensions/f/fmin_s.riscv.ll
@@ -1,0 +1,6 @@
+define dso_local noundef float @mins(float noundef %x, float noundef %y, float noundef %z) local_unnamed_addr #0 {
+entry:
+  %1 = call float @llvm.minnum.f32(float %x, float %y)
+  %2 = call float @llvm.minnum.f32(float %z, float %1)
+  ret float %2
+}


### PR DESCRIPTION
[llvm.minimumnum](https://llvm.org/docs/LangRef.html#llvm-minimumnum-intrinsic) and [llvm.maximumnum](https://llvm.org/docs/LangRef.html#llvm-maximumnum-intrinsic) seem to be semantically closest to the RISC-V instructions, but NaNs may not yet be bit-perfect, and flags need to be set.