### PR TITLE
Lift to correct intrinsics for FMIN/FMAX

### DIFF
--- a/backend_tv/mc2llvm.h
+++ b/backend_tv/mc2llvm.h
@@ -387,13 +387,13 @@ public:
 
   llvm::Value *createMinimumNum(llvm::Value *a, llvm::Value *b) override {
     auto decl = llvm::Intrinsic::getOrInsertDeclaration(
-        LiftedModule, llvm::Intrinsic::minnum, a->getType());
+        LiftedModule, llvm::Intrinsic::minimumnum, a->getType());
     return llvm::CallInst::Create(decl, {a, b}, nextName(), LLVMBB);
   }
 
   llvm::Value *createMaximumNum(llvm::Value *a, llvm::Value *b) override {
     auto decl = llvm::Intrinsic::getOrInsertDeclaration(
-        LiftedModule, llvm::Intrinsic::maxnum, a->getType());
+        LiftedModule, llvm::Intrinsic::maximumnum, a->getType());
     return llvm::CallInst::Create(decl, {a, b}, nextName(), LLVMBB);
   }
 

--- a/tests/riscv-tv/extensions/f/maximumnum.riscv.ll
+++ b/tests/riscv-tv/extensions/f/maximumnum.riscv.ll
@@ -1,0 +1,4 @@
+define float @f(float %0, float %1) {
+  %3 = call float @llvm.maximumnum.f32(float %0, float %1)
+  ret float %3
+}

--- a/tests/riscv-tv/extensions/f/minimumnum.riscv.ll
+++ b/tests/riscv-tv/extensions/f/minimumnum.riscv.ll
@@ -1,0 +1,4 @@
+define float @f(float %0, float %1) {
+  %3 = call float @llvm.minimumnum.f32(float %0, float %1)
+  ret float %3
+}


### PR DESCRIPTION
Just a typo. Slightly different semantics.