### PR TITLE
Inline assembly prototype for backend-tv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,7 @@ if (BUILD_LLVM_UTILS OR BUILD_TV)
 
   set(BACKEND_TV_SRCS
     "backend_tv/lifter.cpp"
+    "backend_tv/inline_asm_lift.cpp"
     "backend_tv/mc2llvm.cpp"
     "backend_tv/run_backend.cpp"
     "backend_tv/streamerwrapper.cpp"
@@ -332,6 +333,19 @@ add_custom_target("check"
 
 if (BUILD_TV)
   add_dependencies("check" "alive-tv" "backend-tv" "quick-fuzz" "tv")
+
+  # Run only the inline-asm lifting tests. Standalone target -- doesn't need
+  # aslp-server because every inline-asm test uses ; SKIP-IDENTITY and the
+  # main verification path explicitly sets ASLP=0.
+  add_custom_target("check-inline-asm"
+                    COMMAND "python3"
+                            "${PROJECT_SOURCE_DIR}/tests/lit/lit.py"
+                            "-s"
+                            "${PROJECT_SOURCE_DIR}/tests/inline-asm"
+                            "-j${TEST_NTHREADS}"
+                    DEPENDS "alive-tv"
+                    USES_TERMINAL
+                   )
 endif()
 
 # EXTERNAL_PROJECTS option that works analogous to LLVM's LLVM_EXTERNAL_PROJECTS option

--- a/backend_tv/inline_asm_lift.cpp
+++ b/backend_tv/inline_asm_lift.cpp
@@ -1,0 +1,359 @@
+#include "backend_tv/inline_asm_lift.h"
+#include "backend_tv/lifter.h"
+
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/TargetParser/Triple.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+using namespace std;
+using namespace llvm;
+
+namespace lifter {
+
+// Max bit-width of a flattened multi-output struct return. mc2llvm's
+// checkSupport rejects scalar returns wider than 64 bits.
+static constexpr unsigned kMaxFlattenedReturnBits = 64;
+
+// All scalar wrapper-name construction goes through this so the wrapper
+// and the matching stub stay in sync.
+static std::string asmWrapName(size_t idx) {
+  return "__asm_wrap_" + std::to_string(idx);
+}
+
+static bool isStructReturn(Type *ty) {
+  return ty->isStructTy();
+}
+
+// Multi-output asm round-trips only when every field is a plain integer
+// and the packed width fits in `kMaxFlattenedReturnBits`. Other shapes
+// (pointer/float/vector/nested aggregate fields, arrays) need work that
+// we don't do yet
+static bool canFlattenStructReturn(StructType *st, const DataLayout &DL,
+                                   std::ostream *out) {
+  unsigned totalBits = 0;
+  for (unsigned i = 0; i < st->getNumElements(); ++i) {
+    Type *fieldTy = st->getElementType(i);
+    if (!fieldTy->isIntegerTy()) {
+      *out << "ERROR: multi-output inline asm with non-integer field "
+              "type at index "
+           << i << " not supported\n";
+      return false;
+    }
+    totalBits += DL.getTypeSizeInBits(fieldTy);
+  }
+  if (totalBits == 0 || totalBits > kMaxFlattenedReturnBits) {
+    *out << "ERROR: multi-output inline asm with " << totalBits
+         << "-bit packed return not supported (max "
+         << kMaxFlattenedReturnBits << ")\n";
+    return false;
+  }
+  return true;
+}
+
+static Type *getFlattenedReturnType(StructType *st, LLVMContext &Ctx,
+                                    const DataLayout &DL) {
+  unsigned totalBits = 0;
+  for (unsigned i = 0; i < st->getNumElements(); ++i) {
+    totalBits += DL.getTypeSizeInBits(st->getElementType(i));
+  }
+  return Type::getIntNTy(Ctx, totalBits);
+}
+
+static void copyTargetAttrs(const Function &from, Function &to) {
+  for (StringRef attrName : {"target-features", "target-cpu", "tune-cpu"}) {
+    if (from.hasFnAttribute(attrName))
+      to.addFnAttr(attrName,
+                   from.getFnAttribute(attrName).getValueAsString());
+  }
+}
+
+// One-call wrapper around `CB`. Struct returns get packed into a wide int.
+static Function *buildAsmWrapper(CallBase &CB, Module &wrapMod, size_t idx) {
+  auto *iasm = cast<InlineAsm>(CB.getCalledOperand());
+  auto &Ctx = wrapMod.getContext();
+  auto &DL = wrapMod.getDataLayout();
+
+  vector<Type *> argTypes;
+  for (unsigned i = 0; i < CB.arg_size(); ++i)
+    argTypes.push_back(CB.getArgOperand(i)->getType());
+
+  Type *origRetTy = CB.getType();
+  Type *wrapRetTy = origRetTy;
+
+  bool flattenStruct = isStructReturn(origRetTy);
+  StructType *structTy = nullptr;
+  if (flattenStruct) {
+    structTy = cast<StructType>(origRetTy);
+    wrapRetTy = getFlattenedReturnType(structTy, Ctx, DL);
+  }
+
+  FunctionType *wrapFTy = FunctionType::get(wrapRetTy, argTypes, false);
+
+  Function *wrapFn = Function::Create(wrapFTy, GlobalValue::ExternalLinkage,
+                                      asmWrapName(idx), &wrapMod);
+  if (const Function *origFn = CB.getFunction())
+    copyTargetAttrs(*origFn, *wrapFn);
+
+  BasicBlock *BB = BasicBlock::Create(Ctx, "entry", wrapFn);
+  IRBuilder<> Builder(BB);
+
+  vector<Value *> args;
+  for (auto &arg : wrapFn->args())
+    args.push_back(&arg);
+
+  InlineAsm *newAsm = InlineAsm::get(
+      cast<FunctionType>(iasm->getFunctionType()), iasm->getAsmString(),
+      iasm->getConstraintString(), iasm->hasSideEffects(),
+      iasm->isAlignStack(), iasm->getDialect());
+
+  CallInst *asmCall = Builder.CreateCall(newAsm, args);
+  // preserve call-site attrs (e.g. elementtype for indirect-mem constraints)
+  asmCall->setAttributes(CB.getAttributes());
+
+  Value *result = asmCall;
+
+  if (origRetTy->isVoidTy()) {
+    Builder.CreateRetVoid();
+  } else if (flattenStruct) {
+    Value *packed = ConstantInt::get(wrapRetTy, 0);
+    unsigned offset = 0;
+    for (unsigned i = 0; i < structTy->getNumElements(); ++i) {
+      Value *field = Builder.CreateExtractValue(result, {i});
+      unsigned fieldBits = DL.getTypeSizeInBits(structTy->getElementType(i));
+      Value *ext = Builder.CreateZExt(field, wrapRetTy);
+      if (offset > 0)
+        ext = Builder.CreateShl(ext, offset);
+      packed = Builder.CreateOr(packed, ext);
+      offset += fieldBits;
+    }
+    Builder.CreateRet(packed);
+  } else {
+    Builder.CreateRet(result);
+  }
+
+  return wrapFn;
+}
+
+int liftInlineAsmCalls(Function &F, const InlineAsmLiftOptions &opts) {
+  assert(opts.out && "InlineAsmLiftOptions::out must be non-null");
+
+  vector<CallBase *> asmCalls;
+  const DataLayout &moduleDL = F.getParent()->getDataLayout();
+
+  for (auto &BB : F) {
+    for (auto &I : BB) {
+      auto *CB = dyn_cast<CallBase>(&I);
+      if (!CB || !isa<InlineAsm>(CB->getCalledOperand()))
+        continue;
+      if (isa<CallBrInst>(CB)) {
+        *opts.out << "ERROR: callbr (asm-goto) not supported for "
+                     "inline asm lifting\n";
+        return -1;
+      }
+      if (CB->hasOperandBundles()) {
+        *opts.out << "ERROR: inline asm with operand bundles not "
+                     "supported\n";
+        return -1;
+      }
+      Type *retTy = CB->getType();
+      if (retTy->isArrayTy()) {
+        *opts.out << "ERROR: inline asm with array return type not "
+                     "supported\n";
+        return -1;
+      }
+      if (auto *st = dyn_cast<StructType>(retTy)) {
+        if (!canFlattenStructReturn(st, moduleDL, opts.out))
+          return -1;
+      }
+      asmCalls.push_back(CB);
+    }
+  }
+
+  if (asmCalls.empty())
+    return 0;
+
+  *opts.out << "Found " << asmCalls.size()
+            << " inline asm call(s) to lift\n";
+
+  auto &tctx = opts.tctx;
+  int lifted = 0;
+
+  for (size_t idx = 0; idx < asmCalls.size(); ++idx) {
+    CallBase *CB = asmCalls[idx];
+
+    *opts.out << "\n--- Lifting inline asm site " << idx << " ---\n";
+
+    LLVMContext &Ctx = F.getContext();
+
+    auto wrapMod = make_unique<Module>("AsmWrapModule", Ctx);
+    wrapMod->setTargetTriple(tctx.TT);
+    wrapMod->setDataLayout(tctx.DL);
+
+    Function *wrapFn = buildAsmWrapper(*CB, *wrapMod, idx);
+
+    string verifyErr;
+    raw_string_ostream verifyOS(verifyErr);
+    if (verifyFunction(*wrapFn, &verifyOS)) {
+      *opts.out << "ERROR: wrapper function verification failed: "
+                << verifyErr << "\n";
+      return -1;
+    }
+
+    *opts.out << "Wrapper module:\n" << moduleToString(wrapMod.get()) << "\n";
+
+    auto asmBuffer =
+        generateAsm(*wrapMod, tctx.Targ, tctx.TT, tctx.CPU, tctx.Features);
+
+    *opts.out << "Generated assembly:\n"
+              << asmBuffer->getBuffer().str() << "\n";
+
+    auto stubMod = make_unique<Module>("StubModule", Ctx);
+    stubMod->setTargetTriple(tctx.TT);
+    stubMod->setDataLayout(tctx.DL);
+
+    // Use the wrapper's function type (which has flattened struct returns)
+    // and the same symbol name so mc2llvm matches the asm function.
+    FunctionType *fTy = wrapFn->getFunctionType();
+    Function *stubFn = Function::Create(fTy, GlobalValue::ExternalLinkage,
+                                        asmWrapName(idx), stubMod.get());
+
+    BasicBlock *stubBB = BasicBlock::Create(Ctx, "entry", stubFn);
+    Type *retTy = fTy->getReturnType();
+    if (retTy->isVoidTy())
+      ReturnInst::Create(Ctx, stubBB);
+    else
+      ReturnInst::Create(Ctx, UndefValue::get(retTy), stubBB);
+
+    unordered_map<unsigned, Instruction *> lineMap;
+    addDebugInfo(stubFn, lineMap);
+
+    auto [adjSrc, liftedTgt] =
+        liftFunc(stubFn, std::move(asmBuffer), lineMap, "O1", opts.out,
+                 tctx.Targ, tctx.TT, tctx.CPU, tctx.Features);
+
+    *opts.out << "Lifted function:\n"
+              << moduleToString(liftedTgt->getParent()) << "\n";
+
+    Module *parentMod = F.getParent();
+
+    Function *importedFn = Function::Create(
+        liftedTgt->getFunctionType(), GlobalValue::InternalLinkage,
+        liftedTgt->getName().str() + "_imported", parentMod);
+
+    ValueToValueMapTy VMap;
+    for (auto srcArg = liftedTgt->arg_begin(),
+              dstArg = importedFn->arg_begin();
+         srcArg != liftedTgt->arg_end(); ++srcArg, ++dstArg) {
+      VMap[&*srcArg] = &*dstArg;
+      dstArg->setName(srcArg->getName());
+    }
+
+    SmallVector<ReturnInst *, 4> Returns;
+    CloneFunctionInto(importedFn, liftedTgt, VMap,
+                      CloneFunctionChangeType::DifferentModule, Returns);
+
+    IRBuilder<> Builder(CB);
+    Builder.SetCurrentDebugLocation(CB->getDebugLoc());
+
+    vector<Value *> callArgs;
+    for (unsigned i = 0; i < CB->arg_size(); ++i)
+      callArgs.push_back(CB->getArgOperand(i));
+
+    CallInst *newCI = Builder.CreateCall(importedFn, callArgs);
+    Value *newResult = newCI;
+
+    Type *origRetTy = CB->getType();
+    if (!origRetTy->isVoidTy()) {
+      if (isStructReturn(origRetTy)) {
+        auto *structTy = cast<StructType>(origRetTy);
+        Value *packed = newCI;
+        Value *unpacked = UndefValue::get(origRetTy);
+        unsigned offset = 0;
+        for (unsigned i = 0; i < structTy->getNumElements(); ++i) {
+          Type *elemTy = structTy->getElementType(i);
+          unsigned fieldBits = moduleDL.getTypeSizeInBits(elemTy);
+          Value *shifted = packed;
+          if (offset > 0)
+            shifted = Builder.CreateLShr(packed, offset);
+          Value *trunced = Builder.CreateTrunc(shifted, elemTy);
+          unpacked = Builder.CreateInsertValue(unpacked, trunced, {i});
+          offset += fieldBits;
+        }
+        newResult = unpacked;
+      }
+      CB->replaceAllUsesWith(newResult);
+    }
+    CB->eraseFromParent();
+
+    InlineFunctionInfo IFI;
+    InlineResult inlineRes = InlineFunction(*newCI, IFI);
+    if (!inlineRes.isSuccess()) {
+      *opts.out << "ERROR: failed to inline lifted asm body: "
+                << inlineRes.getFailureReason() << "\n";
+      return -1;
+    }
+    if (importedFn->use_empty())
+      importedFn->eraseFromParent();
+
+    ++lifted;
+    *opts.out << "Successfully lifted inline asm site " << idx << "\n";
+  }
+
+  return lifted;
+}
+
+static bool hasInlineAsm(Function &F) {
+  for (auto &BB : F)
+    for (auto &I : BB)
+      if (auto *CB = dyn_cast<CallBase>(&I))
+        if (isa<InlineAsm>(CB->getCalledOperand()))
+          return true;
+  return false;
+}
+
+bool tryLiftInlineAsm(Function &F, std::ostream *out) {
+  if (!hasInlineAsm(F))
+    return true;
+
+  static bool targetInited = false;
+  static TargetCtx tctx;
+  if (!targetInited) {
+    auto *M = F.getParent();
+    Triple TT(M->getTargetTriple());
+    if (TT.getArch() == Triple::UnknownArch) {
+      *out << "WARNING: module has no target triple; defaulting to "
+              "aarch64-unknown-linux-gnu for inline asm lifting. Set "
+              "`target triple` in the IR to silence this and ensure "
+              "correct codegen.\n";
+      TT = Triple("aarch64-unknown-linux-gnu");
+    }
+    const auto &dlStr = M->getDataLayoutStr();
+    tctx = initTargetFromTriple(
+        TT, dlStr.empty() ? nullptr : dlStr.c_str(), out);
+    targetInited = true;
+  }
+
+  InlineAsmLiftOptions opts{tctx, out};
+  int result = liftInlineAsmCalls(F, opts);
+  if (result < 0) {
+    *out << "ERROR: failed to lift inline asm in @" << F.getName().str()
+         << "\n";
+    return false;
+  }
+  *out << "Lifted " << result << " inline asm call(s) in @"
+       << F.getName().str() << "\n";
+  return true;
+}
+
+} // namespace lifter

--- a/backend_tv/inline_asm_lift.h
+++ b/backend_tv/inline_asm_lift.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "backend_tv/lifter.h"
+#include "llvm/IR/Function.h"
+#include <ostream>
+
+namespace lifter {
+
+struct InlineAsmLiftOptions {
+  TargetCtx tctx;
+  std::ostream *out;
+};
+
+bool tryLiftInlineAsm(llvm::Function &F, std::ostream *out);
+
+// Lift every `call asm` in F to pure IR via the backend-tv pipeline
+// (generateAsm + mc2llvm lift) and inline the result.
+// Returns the number of sites lifted, or -1 on error.
+// Known semantic gaps in the round-trip:
+//   - `~{memory}` clobbers and other compiler-fence-style side effects
+//     are not represented in the lifted IR; surrounding code may
+//     legally be reordered across the lifted region in ways the
+//     original asm forbade
+int liftInlineAsmCalls(llvm::Function &F, const InlineAsmLiftOptions &opts);
+
+} // namespace lifter

--- a/backend_tv/lifter.cpp
+++ b/backend_tv/lifter.cpp
@@ -71,6 +71,60 @@ void addDebugInfo(Function *srcFn,
   verifyModule(M);
 }
 
+static void initAArch64Backend() {
+  LLVMInitializeAArch64TargetInfo();
+  LLVMInitializeAArch64Target();
+  LLVMInitializeAArch64TargetMC();
+  LLVMInitializeAArch64AsmParser();
+  LLVMInitializeAArch64AsmPrinter();
+}
+
+static void initRISCVBackend() {
+  LLVMInitializeRISCVTargetInfo();
+  LLVMInitializeRISCVTarget();
+  LLVMInitializeRISCVTargetMC();
+  LLVMInitializeRISCVAsmParser();
+  LLVMInitializeRISCVAsmPrinter();
+}
+
+TargetCtx initTargetFromTriple(const Triple &TT, const char *DL,
+                               std::ostream *out) {
+  TargetCtx ctx{};
+  ctx.TT = TT;
+  ctx.CPU = "generic";
+
+  switch (TT.getArch()) {
+  case Triple::aarch64:
+  case Triple::aarch64_be:
+    ctx.DL = DL ? DL
+                : "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32";
+    ctx.Features = "";
+    initAArch64Backend();
+    break;
+  case Triple::riscv64:
+    ctx.DL = DL ? DL : "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128";
+    ctx.Features = "+c,+m,+b,+f,+d,+q,+zfh";
+    initRISCVBackend();
+    break;
+  default:
+    if (out)
+      *out << "ERROR: unsupported target triple arch for inline asm lifting: "
+           << TT.getArchName().str() << "\n";
+    exit(-1);
+  }
+
+  std::string Error;
+  ctx.Targ = TargetRegistry::lookupTarget(ctx.TT, Error);
+  if (!ctx.Targ) {
+    if (out) {
+      *out << "Can't lookup target\n";
+      *out << Error;
+    }
+    exit(-1);
+  }
+  return ctx;
+}
+
 pair<Function *, Function *>
 liftFunc(Function *srcFn, unique_ptr<MemoryBuffer> MB,
          std::unordered_map<unsigned, llvm::Instruction *> &lineMap,

--- a/backend_tv/lifter.h
+++ b/backend_tv/lifter.h
@@ -6,6 +6,7 @@
 #include "llvm/IR/DIBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/MC/TargetRegistry.h"
+#include "llvm/TargetParser/Triple.h"
 
 namespace llvm {
 class Constant;
@@ -14,6 +15,19 @@ class VectorType;
 } // namespace llvm
 
 namespace lifter {
+
+struct TargetCtx {
+  llvm::Triple TT;
+  const char *DL;
+  const char *CPU;
+  const char *Features;
+  const llvm::Target *Targ;
+};
+
+// Init target backend (aarch64/riscv64) from `TT`. `DL` may be nullptr to use
+// the per-arch default datalayout. Calls exit(-1) on unsupported arch.
+TargetCtx initTargetFromTriple(const llvm::Triple &TT, const char *DL,
+                               std::ostream *out);
 
 /*
  * add debug into to an IR file that will help the lifter figure out

--- a/backend_tv/mc2llvm.cpp
+++ b/backend_tv/mc2llvm.cpp
@@ -660,7 +660,7 @@ pair<Function *, Function *> mc2llvm::run() {
   assert(Parser);
 
   unique_ptr<MCTargetAsmParser> TAP(
-      Targ->createMCAsmParser(*STI.get(), *Parser, *MCII.get(), MCOptions));
+      Targ->createMCAsmParser(*STI.get(), *Parser, *MCII.get()));
   assert(TAP);
   Parser->setTargetParser(*TAP);
 

--- a/backend_tv/mc2llvm.h
+++ b/backend_tv/mc2llvm.h
@@ -95,7 +95,7 @@ public:
         MCOptions{llvm::mc::InitMCTargetOptionsFromFlags()},
         MAI{Targ->createMCAsmInfo(*MRI, DefaultTT, MCOptions)},
         MCCtx{std::make_unique<llvm::MCContext>(
-            DefaultTT, MAI.get(), MRI.get(), STI.get(), &SrcMgr, &MCOptions)},
+            DefaultTT, *MAI, MRI.get(), STI.get(), &SrcMgr)},
         MCE{Targ->createMCCodeEmitter(*MCII.get(), *MCCtx.get())},
         MB{std::move(MB)}, lineMap{lineMap}, out{out} {}
 

--- a/tests/inline-asm/arith.aarch64.srctgt.ll
+++ b/tests/inline-asm/arith.aarch64.srctgt.ll
@@ -1,0 +1,150 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- add_reg ----
+define i32 @src(i32 %a, i32 %b) {
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "add ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- sub_reg ----
+define i32 @src_sub_reg(i32 %a, i32 %b) {
+  %r = sub i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_sub_reg(i32 %a, i32 %b) {
+  %r = call i32 asm "sub ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- mul_reg ----
+define i32 @src_mul_reg(i32 %a, i32 %b) {
+  %r = mul i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_mul_reg(i32 %a, i32 %b) {
+  %r = call i32 asm "mul ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- neg ----
+define i32 @src_neg(i32 %a) {
+  %r = sub i32 0, %a
+  ret i32 %r
+}
+
+define i32 @tgt_neg(i32 %a) {
+  %r = call i32 asm "neg ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- add_imm ----
+define i32 @src_add_imm(i32 %a) {
+  %r = add i32 %a, 42
+  ret i32 %r
+}
+
+define i32 @tgt_add_imm(i32 %a) {
+  %r = call i32 asm "add ${0:w}, ${1:w}, #42", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- sub_imm ----
+define i32 @src_sub_imm(i32 %a) {
+  %r = sub i32 %a, 100
+  ret i32 %r
+}
+
+define i32 @tgt_sub_imm(i32 %a) {
+  %r = call i32 asm "sub ${0:w}, ${1:w}, #100", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- add64 ----
+define i64 @src_add64(i64 %a, i64 %b) {
+  %r = add i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_add64(i64 %a, i64 %b) {
+  %r = call i64 asm "add $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- sub64 ----
+define i64 @src_sub64(i64 %a, i64 %b) {
+  %r = sub i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_sub64(i64 %a, i64 %b) {
+  %r = call i64 asm "sub $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- mul64 ----
+define i64 @src_mul64(i64 %a, i64 %b) {
+  %r = mul i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_mul64(i64 %a, i64 %b) {
+  %r = call i64 asm "mul $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- add_shifted ----
+define i64 @src_add_shifted(i64 %a, i64 %b) {
+  %shifted = shl i64 %b, 2
+  %r = add i64 %a, %shifted
+  ret i64 %r
+}
+
+define i64 @tgt_add_shifted(i64 %a, i64 %b) {
+  %r = call i64 asm "add $0, $1, $2, lsl #2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- madd ----
+define i32 @src_madd(i32 %a, i32 %b, i32 %c) {
+  %mul = mul i32 %b, %c
+  %r = add i32 %a, %mul
+  ret i32 %r
+}
+
+define i32 @tgt_madd(i32 %a, i32 %b, i32 %c) {
+  %r = call i32 asm "madd ${0:w}, ${1:w}, ${2:w}, ${3:w}", "=r,r,r,r"(i32 %b, i32 %c, i32 %a)
+  ret i32 %r
+}
+
+; ---- multi_inst ----
+define i32 @src_multi_inst(i32 %a, i32 %b) {
+  %sum = add i32 %a, %b
+  %r = sub i32 %sum, %b
+  ret i32 %r
+}
+
+define i32 @tgt_multi_inst(i32 %a, i32 %b) {
+  %r = call i32 asm "add ${0:w}, ${1:w}, ${2:w}\0Asub ${0:w}, ${0:w}, ${2:w}", "=&r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- tied_operand ----
+define i32 @src_tied_operand(i32 %x) {
+  %r = add i32 %x, 1
+  ret i32 %r
+}
+
+define i32 @tgt_tied_operand(i32 %x) {
+  %r = call i32 asm "add ${0:w}, ${1:w}, #1", "=r,0"(i32 %x)
+  ret i32 %r
+}

--- a/tests/inline-asm/arith.riscv64.srctgt.ll
+++ b/tests/inline-asm/arith.riscv64.srctgt.ll
@@ -1,0 +1,62 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "riscv64-unknown-linux-gnu"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+; ---- add_reg ----
+define i64 @src(i64 %a, i64 %b) {
+  %r = add i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt(i64 %a, i64 %b) {
+  %r = call i64 asm "add $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- sub_reg ----
+define i64 @src_sub_reg(i64 %a, i64 %b) {
+  %r = sub i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_sub_reg(i64 %a, i64 %b) {
+  %r = call i64 asm "sub $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- addi ----
+define i64 @src_addi(i64 %a) {
+  %r = add i64 %a, 77
+  ret i64 %r
+}
+
+define i64 @tgt_addi(i64 %a) {
+  %r = call i64 asm "addi $0, $1, 77", "=r,r"(i64 %a)
+  ret i64 %r
+}
+
+; ---- addw ----
+define i64 @src_addw(i64 %a, i64 %b) {
+  %a32 = trunc i64 %a to i32
+  %b32 = trunc i64 %b to i32
+  %sum = add i32 %a32, %b32
+  %r = sext i32 %sum to i64
+  ret i64 %r
+}
+
+define i64 @tgt_addw(i64 %a, i64 %b) {
+  %r = call i64 asm "addw $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- mul ----
+define i64 @src_mul(i64 %a, i64 %b) {
+  %r = mul i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_mul(i64 %a, i64 %b) {
+  %r = call i64 asm "mul $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}

--- a/tests/inline-asm/asm_goto.aarch64.srctgt.ll
+++ b/tests/inline-asm/asm_goto.aarch64.srctgt.ll
@@ -1,0 +1,31 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; CHECK: callbr (asm-goto) not supported
+; callbr / asm goto: branches to a label based on condition inside asm
+
+define i32 @src(i32 %a) {
+entry:
+  %cmp = icmp eq i32 %a, 0
+  br i1 %cmp, label %is_zero, label %not_zero
+
+is_zero:
+  ret i32 0
+
+not_zero:
+  ret i32 %a
+}
+
+define i32 @tgt(i32 %a) {
+entry:
+  callbr void asm "cbz ${0:w}, ${1:l}", "r,!i"(i32 %a)
+    to label %fallthrough [label %is_zero]
+
+fallthrough:
+  ret i32 %a
+
+is_zero:
+  ret i32 0
+}

--- a/tests/inline-asm/bit_count.aarch64.srctgt.ll
+++ b/tests/inline-asm/bit_count.aarch64.srctgt.ll
@@ -1,0 +1,79 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+declare i32 @llvm.ctlz.i32(i32, i1)
+declare i64 @llvm.ctlz.i64(i64, i1)
+declare i32 @llvm.cttz.i32(i32, i1)
+declare i32 @llvm.bitreverse.i32(i32)
+declare i32 @llvm.bswap.i32(i32)
+declare i8 @llvm.ctpop.i8(i8)
+
+; ---- clz ----
+define i32 @src(i32 %a) {
+  %r = call i32 @llvm.ctlz.i32(i32 %a, i1 false)
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a) {
+  %r = call i32 asm "clz ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- ctlz64 ----
+define i64 @src_ctlz64(i64 %a) {
+  %r = call i64 @llvm.ctlz.i64(i64 %a, i1 false)
+  ret i64 %r
+}
+
+define i64 @tgt_ctlz64(i64 %a) {
+  %r = call i64 asm "clz $0, $1", "=r,r"(i64 %a)
+  ret i64 %r
+}
+
+; ---- ctz_via_rbit_clz ----
+define i32 @src_ctz_via_rbit_clz(i32 %a) {
+  %r = call i32 @llvm.cttz.i32(i32 %a, i1 false)
+  ret i32 %r
+}
+
+define i32 @tgt_ctz_via_rbit_clz(i32 %a) {
+  %r = call i32 asm "rbit ${0:w}, ${1:w}\0Aclz ${0:w}, ${0:w}", "=&r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- rbit ----
+define i32 @src_rbit(i32 %a) {
+  %r = call i32 @llvm.bitreverse.i32(i32 %a)
+  ret i32 %r
+}
+
+define i32 @tgt_rbit(i32 %a) {
+  %r = call i32 asm "rbit ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- rev ----
+define i32 @src_rev(i32 %a) {
+  %r = call i32 @llvm.bswap.i32(i32 %a)
+  ret i32 %r
+}
+
+define i32 @tgt_rev(i32 %a) {
+  %r = call i32 asm "rev ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- popcount ----
+define i8 @src_popcount(i8 %a) {
+  %r = call i8 @llvm.ctpop.i8(i8 %a)
+  ret i8 %r
+}
+
+define i8 @tgt_popcount(i8 %a) {
+  %ext = zext i8 %a to i32
+  %cnt = call i32 asm "fmov s0, ${1:w}\0Acnt v0.8b, v0.8b\0Afmov ${0:w}, s0", "=r,r,~{v0}"(i32 %ext)
+  %trunc = trunc i32 %cnt to i8
+  ret i8 %trunc
+}

--- a/tests/inline-asm/bit_ops.riscv64.srctgt.ll
+++ b/tests/inline-asm/bit_ops.riscv64.srctgt.ll
@@ -1,0 +1,41 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "riscv64-unknown-linux-gnu"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+declare i64 @llvm.ctlz.i64(i64, i1)
+declare i64 @llvm.bswap.i64(i64)
+declare i64 @llvm.smax.i64(i64, i64)
+
+; ---- clz ----
+define i64 @src(i64 %a) {
+  %r = call i64 @llvm.ctlz.i64(i64 %a, i1 false)
+  ret i64 %r
+}
+
+define i64 @tgt(i64 %a) {
+  %r = call i64 asm "clz $0, $1", "=r,r"(i64 %a)
+  ret i64 %r
+}
+
+; ---- rev16 ----
+define i64 @src_rev16(i64 %a) {
+  %r = call i64 @llvm.bswap.i64(i64 %a)
+  ret i64 %r
+}
+
+define i64 @tgt_rev16(i64 %a) {
+  %r = call i64 asm "rev8 $0, $1", "=r,r"(i64 %a)
+  ret i64 %r
+}
+
+; ---- max_min ----
+define i64 @src_max_min(i64 %a, i64 %b) {
+  %r = call i64 @llvm.smax.i64(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+define i64 @tgt_max_min(i64 %a, i64 %b) {
+  %r = call i64 asm "max $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}

--- a/tests/inline-asm/bitfield.aarch64.srctgt.ll
+++ b/tests/inline-asm/bitfield.aarch64.srctgt.ll
@@ -1,0 +1,79 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- bfi ----
+define i32 @src(i32 %a, i32 %b) {
+  %mask_a = and i32 %a, -65281       ; clear bits [8:15]: ~0xFF00
+  %field = and i32 %b, 255           ; isolate low 8 bits of b
+  %shifted = shl i32 %field, 8       ; shift into position
+  %r = or i32 %mask_a, %shifted
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "bfi ${0:w}, ${2:w}, #8, #8", "=r,0,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- ubfx ----
+define i32 @src_ubfx(i32 %a) {
+  %shift = lshr i32 %a, 8
+  %r = and i32 %shift, 255
+  ret i32 %r
+}
+
+define i32 @tgt_ubfx(i32 %a) {
+  %r = call i32 asm "ubfx ${0:w}, ${1:w}, #8, #8", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- sxt_pattern ----
+define i32 @src_sxt_pattern(i32 %a) {
+  %trunc = trunc i32 %a to i8
+  %ext = sext i8 %trunc to i32
+  ret i32 %ext
+}
+
+define i32 @tgt_sxt_pattern(i32 %a) {
+  %r = call i32 asm "sxtb ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- uxt_pattern ----
+define i32 @src_uxt_pattern(i32 %a) {
+  %r = and i32 %a, 65535
+  ret i32 %r
+}
+
+define i32 @tgt_uxt_pattern(i32 %a) {
+  %r = call i32 asm "uxth ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- extract_sign ----
+define i32 @src_extract_sign(i32 %x) {
+  %neg = icmp slt i32 %x, 0
+  %r = select i1 %neg, i32 -1, i32 1
+  ret i32 %r
+}
+
+define i32 @tgt_extract_sign(i32 %x) {
+  %r = call i32 asm "cmp ${1:w}, #0\0Amov ${0:w}, #1\0Acsneg ${0:w}, ${0:w}, ${0:w}, ge", "=&r,r,~{nzcv}"(i32 %x)
+  ret i32 %r
+}
+
+; ---- deposit_bits ----
+define i32 @src_deposit_bits(i32 %dst, i32 %val) {
+  %cleared = and i32 %dst, -61441     ; ~(0xF << 12) = 0xFFFF0FFF
+  %field = and i32 %val, 15           ; isolate bits [0:3]
+  %placed = shl i32 %field, 12        ; move to position [12:15]
+  %r = or i32 %cleared, %placed
+  ret i32 %r
+}
+
+define i32 @tgt_deposit_bits(i32 %dst, i32 %val) {
+  %r = call i32 asm "bfi ${0:w}, ${2:w}, #12, #4", "=r,0,r"(i32 %dst, i32 %val)
+  ret i32 %r
+}

--- a/tests/inline-asm/bitwise.aarch64.srctgt.ll
+++ b/tests/inline-asm/bitwise.aarch64.srctgt.ll
@@ -1,0 +1,95 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- and_reg ----
+define i32 @src(i32 %a, i32 %b) {
+  %r = and i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "and ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- orr_reg ----
+define i32 @src_orr_reg(i32 %a, i32 %b) {
+  %r = or i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_orr_reg(i32 %a, i32 %b) {
+  %r = call i32 asm "orr ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- eor_reg ----
+define i32 @src_eor_reg(i32 %a, i32 %b) {
+  %r = xor i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_eor_reg(i32 %a, i32 %b) {
+  %r = call i32 asm "eor ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- mvn ----
+define i32 @src_mvn(i32 %a) {
+  %r = xor i32 %a, -1
+  ret i32 %r
+}
+
+define i32 @tgt_mvn(i32 %a) {
+  %r = call i32 asm "mvn ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- bic ----
+define i32 @src_bic(i32 %a, i32 %b) {
+  %not_b = xor i32 %b, -1
+  %r = and i32 %a, %not_b
+  ret i32 %r
+}
+
+define i32 @tgt_bic(i32 %a, i32 %b) {
+  %r = call i32 asm "bic ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- orn ----
+define i32 @src_orn(i32 %a, i32 %b) {
+  %not_b = xor i32 %b, -1
+  %r = or i32 %a, %not_b
+  ret i32 %r
+}
+
+define i32 @tgt_orn(i32 %a, i32 %b) {
+  %r = call i32 asm "orn ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- eon ----
+define i32 @src_eon(i32 %a, i32 %b) {
+  %not_b = xor i32 %b, -1
+  %r = xor i32 %a, %not_b
+  ret i32 %r
+}
+
+define i32 @tgt_eon(i32 %a, i32 %b) {
+  %r = call i32 asm "eon ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- xor_clobber ----
+define i32 @src_xor_clobber(i32 %a, i32 %b) {
+  %r = xor i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_xor_clobber(i32 %a, i32 %b) {
+  %r = call i32 asm "eor ${0:w}, ${1:w}, ${2:w}", "=r,r,r,~{x9}"(i32 %a, i32 %b)
+  ret i32 %r
+}

--- a/tests/inline-asm/bitwise.riscv64.srctgt.ll
+++ b/tests/inline-asm/bitwise.riscv64.srctgt.ll
@@ -1,0 +1,49 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "riscv64-unknown-linux-gnu"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+; ---- and_reg ----
+define i64 @src(i64 %a, i64 %b) {
+  %r = and i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt(i64 %a, i64 %b) {
+  %r = call i64 asm "and $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- or_reg ----
+define i64 @src_or_reg(i64 %a, i64 %b) {
+  %r = or i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_or_reg(i64 %a, i64 %b) {
+  %r = call i64 asm "or $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- xor_reg ----
+define i64 @src_xor_reg(i64 %a, i64 %b) {
+  %r = xor i64 %a, %b
+  ret i64 %r
+}
+
+define i64 @tgt_xor_reg(i64 %a, i64 %b) {
+  %r = call i64 asm "xor $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- andn ----
+define i64 @src_andn(i64 %a, i64 %b) {
+  %not_b = xor i64 %b, -1
+  %r = and i64 %a, %not_b
+  ret i64 %r
+}
+
+define i64 @tgt_andn(i64 %a, i64 %b) {
+  %r = call i64 asm "andn $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}

--- a/tests/inline-asm/both_sides.aarch64.srctgt.ll
+++ b/tests/inline-asm/both_sides.aarch64.srctgt.ll
@@ -1,0 +1,16 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Both src and tgt contain inline asm; both get lifted before comparison.
+
+define i32 @src(i32 %a, i32 %b) {
+  %r = call i32 asm "add ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "add ${0:w}, ${2:w}, ${1:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}

--- a/tests/inline-asm/cls.aarch64.srctgt.ll
+++ b/tests/inline-asm/cls.aarch64.srctgt.ll
@@ -1,0 +1,22 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+; XFAIL: Unsupported instruction
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Count leading sign bits: cls = clz(x ^ (x >> 31)) - 1 for i32
+
+define i32 @src(i32 %a) {
+  %shift = ashr i32 %a, 31
+  %x = xor i32 %a, %shift
+  %clz = call i32 @llvm.ctlz.i32(i32 %x, i1 false)
+  %r = sub i32 %clz, 1
+  ret i32 %r
+}
+
+declare i32 @llvm.ctlz.i32(i32, i1)
+
+define i32 @tgt(i32 %a) {
+  %r = call i32 asm "cls ${0:w}, ${1:w}", "=r,r"(i32 %a)
+  ret i32 %r
+}

--- a/tests/inline-asm/conditional.aarch64.srctgt.ll
+++ b/tests/inline-asm/conditional.aarch64.srctgt.ll
@@ -1,0 +1,56 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+declare i32 @llvm.abs.i32(i32, i1)
+
+; ---- csel ----
+define i32 @src(i32 %a, i32 %b, i32 %c) {
+  %cmp = icmp sgt i32 %c, 0
+  %r = select i1 %cmp, i32 %a, i32 %b
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b, i32 %c) {
+  %r = call i32 asm "cmp ${3:w}, #0\0Acsel ${0:w}, ${1:w}, ${2:w}, gt", "=r,r,r,r"(i32 %a, i32 %b, i32 %c)
+  ret i32 %r
+}
+
+; ---- conditional_negate ----
+define i32 @src_conditional_negate(i32 %val, i32 %cond) {
+  %is_neg = icmp eq i32 %cond, 0
+  %negated = sub i32 0, %val
+  %r = select i1 %is_neg, i32 %negated, i32 %val
+  ret i32 %r
+}
+
+define i32 @tgt_conditional_negate(i32 %val, i32 %cond) {
+  %r = call i32 asm "cmp ${2:w}, #0\0Acsneg ${0:w}, ${1:w}, ${1:w}, ne", "=r,r,r,~{nzcv}"(i32 %val, i32 %cond)
+  ret i32 %r
+}
+
+; ---- abs_idiom ----
+define i32 @src_abs_idiom(i32 %a) {
+  %r = call i32 @llvm.abs.i32(i32 %a, i1 false)
+  ret i32 %r
+}
+
+define i32 @tgt_abs_idiom(i32 %a) {
+  %r = call i32 asm "cmp ${1:w}, #0\0Acneg ${0:w}, ${1:w}, mi", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- min_max_pair ----
+define i32 @src_min_max_pair(i32 %x, i32 %lo, i32 %hi) {
+  %cmp_lo = icmp slt i32 %x, %lo
+  %s1 = select i1 %cmp_lo, i32 %lo, i32 %x
+  %cmp_hi = icmp sgt i32 %s1, %hi
+  %r = select i1 %cmp_hi, i32 %hi, i32 %s1
+  ret i32 %r
+}
+
+define i32 @tgt_min_max_pair(i32 %x, i32 %lo, i32 %hi) {
+  %r = call i32 asm "cmp ${1:w}, ${2:w}\0Acsel ${0:w}, ${2:w}, ${1:w}, lt\0Acmp ${0:w}, ${3:w}\0Acsel ${0:w}, ${3:w}, ${0:w}, gt", "=&r,r,r,r"(i32 %x, i32 %lo, i32 %hi)
+  ret i32 %r
+}

--- a/tests/inline-asm/divide_by_3.aarch64.srctgt.ll
+++ b/tests/inline-asm/divide_by_3.aarch64.srctgt.ll
@@ -1,0 +1,20 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Unsigned divide by 3 using multiply-high trick:
+; x / 3 = (x * 0xAAAAAAAB) >> 33  (for 32-bit unsigned)
+; LLVM knows this trick, but here we verify the asm version is correct.
+; src: straightforward udiv
+; tgt: the classic multiply-and-shift asm idiom
+
+define i32 @src(i32 %x) {
+  %r = udiv i32 %x, 3
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %x) {
+  %r = call i32 asm "mov ${0:w}, #0xaaab\0Amovk ${0:w}, #0xaaaa, lsl #16\0Aumull $0, ${0:w}, ${1:w}\0Alsr $0, $0, #33\0Amov ${0:w}, ${0:w}", "=&r,r"(i32 %x)
+  ret i32 %r
+}

--- a/tests/inline-asm/divmod.aarch64.srctgt.ll
+++ b/tests/inline-asm/divmod.aarch64.srctgt.ll
@@ -1,0 +1,22 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Multi-output: sdiv + msub to get both quotient and remainder
+
+define i32 @src(i32 %a, i32 %b) {
+  %q = sdiv i32 %a, %b
+  %mul = mul i32 %q, %b
+  %rem = sub i32 %a, %mul
+  %r = add i32 %q, %rem
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %result = call {i32, i32} asm "sdiv ${0:w}, ${2:w}, ${3:w}\0Amsub ${1:w}, ${0:w}, ${3:w}, ${2:w}", "=&r,=&r,r,r"(i32 %a, i32 %b)
+  %q = extractvalue {i32, i32} %result, 0
+  %rem = extractvalue {i32, i32} %result, 1
+  %r = add i32 %q, %rem
+  ret i32 %r
+}

--- a/tests/inline-asm/idioms.aarch64.srctgt.ll
+++ b/tests/inline-asm/idioms.aarch64.srctgt.ll
@@ -1,0 +1,79 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- is_power_of_2 ----
+define i1 @src(i32 %x) {
+  %nz = icmp ne i32 %x, 0
+  %dec = sub i32 %x, 1
+  %and = and i32 %x, %dec
+  %no_other_bits = icmp eq i32 %and, 0
+  %r = and i1 %nz, %no_other_bits
+  ret i1 %r
+}
+
+define i1 @tgt(i32 %x) {
+  %wide = call i32 asm "sub ${0:w}, ${1:w}, #1\0Atst ${1:w}, ${0:w}\0Accmp ${1:w}, #0, #4, eq\0Acset ${0:w}, ne", "=&r,r,~{nzcv}"(i32 %x)
+  %r = trunc i32 %wide to i1
+  ret i1 %r
+}
+
+; ---- sat_add_u8 ----
+define i32 @src_sat_add_u8(i32 %a, i32 %b) {
+  %a8 = and i32 %a, 255
+  %b8 = and i32 %b, 255
+  %sum = add i32 %a8, %b8
+  %overflow = icmp ugt i32 %sum, 255
+  %r = select i1 %overflow, i32 255, i32 %sum
+  ret i32 %r
+}
+
+define i32 @tgt_sat_add_u8(i32 %a, i32 %b) {
+  %a8 = and i32 %a, 255
+  %b8 = and i32 %b, 255
+  %sum = add i32 %a8, %b8
+  %r = call i32 asm "cmp ${1:w}, #255\0Amov ${0:w}, #255\0Acsel ${0:w}, ${0:w}, ${1:w}, hi", "=&r,r,~{nzcv}"(i32 %sum)
+  ret i32 %r
+}
+
+; ---- blend_bytes ----
+define i32 @src_blend_bytes(i32 %a, i32 %b, i32 %mask) {
+  %sel_a = and i32 %a, %mask
+  %not_mask = xor i32 %mask, -1
+  %sel_b = and i32 %b, %not_mask
+  %r = or i32 %sel_a, %sel_b
+  ret i32 %r
+}
+
+define i32 @tgt_blend_bytes(i32 %a, i32 %b, i32 %mask) {
+  %r = call i32 asm "and ${0:w}, ${1:w}, ${3:w}\0Abic ${1:w}, ${2:w}, ${3:w}\0Aorr ${0:w}, ${0:w}, ${1:w}", "=&r,r,r,r"(i32 %a, i32 %b, i32 %mask)
+  ret i32 %r
+}
+
+; ---- midpoint_no_overflow ----
+define i32 @src_midpoint_no_overflow(i32 %a, i32 %b) {
+  %and = and i32 %a, %b
+  %xor = xor i32 %a, %b
+  %half_xor = lshr i32 %xor, 1
+  %r = add i32 %and, %half_xor
+  ret i32 %r
+}
+
+define i32 @tgt_midpoint_no_overflow(i32 %a, i32 %b) {
+  %r = call i32 asm "and ${0:w}, ${1:w}, ${2:w}\0Aeor ${1:w}, ${1:w}, ${2:w}\0Aadd ${0:w}, ${0:w}, ${1:w}, lsr #1", "=&r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- complex_expr ----
+define i32 @src_complex_expr(i32 %a, i32 %b, i32 %c, i32 %d) {
+  %mul = mul i32 %a, %b
+  %add = add i32 %mul, %c
+  %r = xor i32 %add, %d
+  ret i32 %r
+}
+
+define i32 @tgt_complex_expr(i32 %a, i32 %b, i32 %c, i32 %d) {
+  %r = call i32 asm "madd ${0:w}, ${1:w}, ${2:w}, ${3:w}\0Aeor ${0:w}, ${0:w}, ${4:w}", "=&r,r,r,r,r"(i32 %a, i32 %b, i32 %c, i32 %d)
+  ret i32 %r
+}

--- a/tests/inline-asm/memory.aarch64.srctgt.ll
+++ b/tests/inline-asm/memory.aarch64.srctgt.ll
@@ -1,0 +1,49 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- memory_load ----
+define i32 @src(ptr %p) {
+  %r = load i32, ptr %p
+  ret i32 %r
+}
+
+define i32 @tgt(ptr %p) {
+  %r = call i32 asm "ldr ${0:w}, $1", "=r,*m"(ptr elementtype(i32) %p)
+  ret i32 %r
+}
+
+; ---- memory_store ----
+define void @src_memory_store(ptr %p, i32 %val) {
+  store i32 %val, ptr %p
+  ret void
+}
+
+define void @tgt_memory_store(ptr %p, i32 %val) {
+  call void asm "str ${0:w}, $1", "r,*m"(i32 %val, ptr elementtype(i32) %p)
+  ret void
+}
+
+; ---- read_modify_write ----
+define void @src_read_modify_write(ptr %p) {
+  %v = load i32, ptr %p
+  %inc = add i32 %v, 1
+  store i32 %inc, ptr %p
+  ret void
+}
+
+define void @tgt_read_modify_write(ptr %p) {
+  call void asm "ldr w8, [$0]\0Aadd w8, w8, #1\0Astr w8, [$0]", "r,~{w8},~{memory}"(ptr %p)
+  ret void
+}
+
+; ---- compiler_barrier ----
+define i32 @src_compiler_barrier(i32 %a) {
+  ret i32 %a
+}
+
+define i32 @tgt_compiler_barrier(i32 %a) {
+  call void asm sideeffect "", "~{memory}"()
+  ret i32 %a
+}

--- a/tests/inline-asm/multi_out_simple.aarch64.srctgt.ll
+++ b/tests/inline-asm/multi_out_simple.aarch64.srctgt.ll
@@ -1,0 +1,21 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Multi-output: return both sum and difference
+
+define i32 @src(i32 %a, i32 %b) {
+  %sum = add i32 %a, %b
+  %diff = sub i32 %a, %b
+  %r = xor i32 %sum, %diff
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %result = call {i32, i32} asm "add ${0:w}, ${2:w}, ${3:w}\0Asub ${1:w}, ${2:w}, ${3:w}", "=&r,=&r,r,r"(i32 %a, i32 %b)
+  %sum = extractvalue {i32, i32} %result, 0
+  %diff = extractvalue {i32, i32} %result, 1
+  %r = xor i32 %sum, %diff
+  ret i32 %r
+}

--- a/tests/inline-asm/sdiv.aarch64.srctgt.ll
+++ b/tests/inline-asm/sdiv.aarch64.srctgt.ll
@@ -1,0 +1,16 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; Signed division
+
+define i32 @src(i32 %a, i32 %b) {
+  %r = sdiv i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "sdiv ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}

--- a/tests/inline-asm/shifts.aarch64.srctgt.ll
+++ b/tests/inline-asm/shifts.aarch64.srctgt.ll
@@ -1,0 +1,72 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+declare i32 @llvm.fshr.i32(i32, i32, i32)
+
+; ---- lsl_imm ----
+define i32 @src(i32 %a) {
+  %r = shl i32 %a, 3
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a) {
+  %r = call i32 asm "lsl ${0:w}, ${1:w}, #3", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- lsr_imm ----
+define i32 @src_lsr_imm(i32 %a) {
+  %r = lshr i32 %a, 5
+  ret i32 %r
+}
+
+define i32 @tgt_lsr_imm(i32 %a) {
+  %r = call i32 asm "lsr ${0:w}, ${1:w}, #5", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- asr_imm ----
+define i32 @src_asr_imm(i32 %a) {
+  %r = ashr i32 %a, 4
+  ret i32 %r
+}
+
+define i32 @tgt_asr_imm(i32 %a) {
+  %r = call i32 asm "asr ${0:w}, ${1:w}, #4", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- ror ----
+define i32 @src_ror(i32 %a) {
+  %r = call i32 @llvm.fshr.i32(i32 %a, i32 %a, i32 7)
+  ret i32 %r
+}
+
+define i32 @tgt_ror(i32 %a) {
+  %r = call i32 asm "ror ${0:w}, ${1:w}, #7", "=r,r"(i32 %a)
+  ret i32 %r
+}
+
+; ---- ror_variable ----
+define i32 @src_ror_variable(i32 %a, i32 %n) {
+  %r = call i32 @llvm.fshr.i32(i32 %a, i32 %a, i32 %n)
+  ret i32 %r
+}
+
+define i32 @tgt_ror_variable(i32 %a, i32 %n) {
+  %r = call i32 asm "ror ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %n)
+  ret i32 %r
+}
+
+; ---- extr ----
+define i32 @src_extr(i32 %hi, i32 %lo) {
+  %r = call i32 @llvm.fshr.i32(i32 %hi, i32 %lo, i32 16)
+  ret i32 %r
+}
+
+define i32 @tgt_extr(i32 %hi, i32 %lo) {
+  %r = call i32 asm "extr ${0:w}, ${1:w}, ${2:w}, #16", "=r,r,r"(i32 %hi, i32 %lo)
+  ret i32 %r
+}

--- a/tests/inline-asm/shifts.riscv64.srctgt.ll
+++ b/tests/inline-asm/shifts.riscv64.srctgt.ll
@@ -1,0 +1,39 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "riscv64-unknown-linux-gnu"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+
+; ---- sll_reg ----
+define i64 @src(i64 %a, i64 %b) {
+  %mask = and i64 %b, 63
+  %r = shl i64 %a, %mask
+  ret i64 %r
+}
+
+define i64 @tgt(i64 %a, i64 %b) {
+  %r = call i64 asm "sll $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- srl_reg ----
+define i64 @src_srl_reg(i64 %a, i64 %b) {
+  %mask = and i64 %b, 63
+  %r = lshr i64 %a, %mask
+  ret i64 %r
+}
+
+define i64 @tgt_srl_reg(i64 %a, i64 %b) {
+  %r = call i64 asm "srl $0, $1, $2", "=r,r,r"(i64 %a, i64 %b)
+  ret i64 %r
+}
+
+; ---- srai ----
+define i64 @src_srai(i64 %a) {
+  %r = ashr i64 %a, 10
+  ret i64 %r
+}
+
+define i64 @tgt_srai(i64 %a) {
+  %r = call i64 asm "srai $0, $1, 10", "=r,r"(i64 %a)
+  ret i64 %r
+}

--- a/tests/inline-asm/unsound.aarch64.srctgt.ll
+++ b/tests/inline-asm/unsound.aarch64.srctgt.ll
@@ -1,0 +1,38 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+; CHECK: Transformation doesn't verify!
+
+; ---- unsound ----
+define i32 @src(i32 %a, i32 %b) {
+  %r = add i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt(i32 %a, i32 %b) {
+  %r = call i32 asm "sub ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- unsound_and_vs_or ----
+define i32 @src_unsound_and_vs_or(i32 %a, i32 %b) {
+  %r = and i32 %a, %b
+  ret i32 %r
+}
+
+define i32 @tgt_unsound_and_vs_or(i32 %a, i32 %b) {
+  %r = call i32 asm "orr ${0:w}, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i32 %r
+}
+
+; ---- unsound_lsl_vs_lsr ----
+define i32 @src_unsound_lsl_vs_lsr(i32 %a) {
+  %r = shl i32 %a, 2
+  ret i32 %r
+}
+
+define i32 @tgt_unsound_lsl_vs_lsr(i32 %a) {
+  %r = call i32 asm "lsr ${0:w}, ${1:w}, #2", "=r,r"(i32 %a)
+  ret i32 %r
+}

--- a/tests/inline-asm/widening_mul.aarch64.srctgt.ll
+++ b/tests/inline-asm/widening_mul.aarch64.srctgt.ll
@@ -1,0 +1,45 @@
+; TEST-ARGS: -disable-undef-input -disable-poison-input
+; SKIP-IDENTITY
+target triple = "aarch64-unknown-linux-gnu"
+target datalayout = "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32"
+
+; ---- smull ----
+define i64 @src(i32 %a, i32 %b) {
+  %ea = sext i32 %a to i64
+  %eb = sext i32 %b to i64
+  %r = mul i64 %ea, %eb
+  ret i64 %r
+}
+
+define i64 @tgt(i32 %a, i32 %b) {
+  %r = call i64 asm "smull $0, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i64 %r
+}
+
+; ---- umull ----
+define i64 @src_umull(i32 %a, i32 %b) {
+  %ea = zext i32 %a to i64
+  %eb = zext i32 %b to i64
+  %r = mul i64 %ea, %eb
+  ret i64 %r
+}
+
+define i64 @tgt_umull(i32 %a, i32 %b) {
+  %r = call i64 asm "umull $0, ${1:w}, ${2:w}", "=r,r,r"(i32 %a, i32 %b)
+  ret i64 %r
+}
+
+; ---- mulhi_u32 ----
+define i32 @src_mulhi_u32(i32 %a, i32 %b) {
+  %ea = zext i32 %a to i64
+  %eb = zext i32 %b to i64
+  %prod = mul i64 %ea, %eb
+  %hi = lshr i64 %prod, 32
+  %r = trunc i64 %hi to i32
+  ret i32 %r
+}
+
+define i32 @tgt_mulhi_u32(i32 %a, i32 %b) {
+  %r = call i32 asm "umull x0, ${1:w}, ${2:w}\0Alsr x0, x0, #32\0Amov ${0:w}, w0", "=r,r,r,~{x0}"(i32 %a, i32 %b)
+  ret i32 %r
+}

--- a/tools/alive-tv.cpp
+++ b/tools/alive-tv.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-present The Alive2 Authors.
 // Distributed under the MIT license that can be found in the LICENSE file.
 
+#include "backend_tv/inline_asm_lift.h"
 #include "cache/cache.h"
 #include "llvm_util/compare.h"
 #include "llvm_util/llvm2alive.h"
@@ -175,6 +176,10 @@ and "tgt5" will unused.
       auto TGT = findFunction(*M1, DstFName);
       if (SRC && TGT) {
         ++Cnt;
+        if (!lifter::tryLiftInlineAsm(*SRC, out))
+          goto end;
+        if (!lifter::tryLiftInlineAsm(*TGT, out))
+          goto end;
         if (!verifier.compareFunctions(*SRC, *TGT))
           if (opt_error_fatal)
             goto end;
@@ -227,6 +232,10 @@ and "tgt5" will unused.
         M2_anon_count++;
       if ((F1.getName().empty() && (M1_anon_count == M2_anon_count)) ||
           (F1.getName() == F2.getName())) {
+        if (!lifter::tryLiftInlineAsm(F1, out))
+          goto end;
+        if (!lifter::tryLiftInlineAsm(F2, out))
+          goto end;
         if (!verifier.compareFunctions(F1, F2))
           if (opt_error_fatal)
             goto end;


### PR DESCRIPTION
Treat asm calls as tiny assembly functions
  Lifts to LLVM IR for backends supported by backend-tv
  Inline into the caller function, RAUW
  Verify with alive-tv
  Works with asm in both src and tgt
    
Calls/jumps to arbitrary labels unsupported, won't implement
  
Can support in future, does not work yet :
  Operand bundles, weird return types
  Non SSA communication between multiple inline assembly blocks
  Memory clobber effects
 
Tested for aarch64 and riscv